### PR TITLE
Added scaling option in optimizer_target_density.sh

### DIFF
--- a/share/scripts/inverse/optimizer_target_density.sh
+++ b/share/scripts/inverse/optimizer_target_density.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+# Copyright 2009-2016 The VOTCA Development Team (http://www.votca.org)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/share/scripts/inverse/optimizer_target_density.sh
+++ b/share/scripts/inverse/optimizer_target_density.sh
@@ -31,7 +31,9 @@ name="$(csg_get_interaction_property name)"
 mol="$(csg_get_interaction_property inverse.optimizer.density.molname)"
 axis="$(csg_get_interaction_property inverse.optimizer.density.axis)"
 step="$(csg_get_interaction_property inverse.optimizer.density.step)"
-opts=( "--molname" "$mol" "--axis" "$axis" "--step" "$step" )
+# added scale
+scale="$(csg_get_interaction_property inverse.optimizer.density.scale)"
+opts=( "--molname" "$mol" "--axis" "$axis" "--step" "$step" "--scale" "$scale")
 do_external density ${sim_prog} "${name}.density.new" "${opts[@]}"
 
 [[ -f ${name}.density.new ]] || die "${0##*/}: Could not calculate ${name}.density.new"

--- a/share/xml/csg_defaults.xml.in
+++ b/share/xml/csg_defaults.xml.in
@@ -685,6 +685,9 @@
           <step>
             <DESC>Step size of interval in which density calculation is performed.</DESC>
           </step>
+               <scale>1.0
+               <DESC>Scaling factor for density</DESC>
+               </scale>
 	        <molname>*
 	        <DESC>The molname of this interaction</DESC>
 	        </molname>


### PR DESCRIPTION
A portion of settings.xml file:

``` xml
<cg>
     .
     .
     .
      <lammps>
        <!-- name of the table for lammps run -->
        <table>CG_CG.pot</table>
        <table_begin>2.0</table_begin>
        <table_bins>0.025</table_bins>
      </lammps>
      <optimizer>
        .
        .
        .
        <density>
          <target>CG-CG.density.tgt</target>
          <min>0</min>
          <max>80</max>
          <step>0.5</step>
          <axis>z</axis>
          <!-- Scaling factor for density -->
          <scale>1.66054</scale>
        </density>
        </optimizer>
     .
     .
     .
</cg>
```
