### PR TITLE
Remove assertion on IBond, IAngle, IDihedral (reverts partially commit: votca/csg@f7b149b5dd)

### DIFF
--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -89,7 +89,7 @@ public:
         { _beads.resize(2); _beads[0] = bead1; _beads[1] = bead2; }
 
     IBond(list<int> &beads)
-        { assert(beads.size()<2); _beads.resize(2); for(int i=0; i<2; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
+        { _beads.resize(2); for(int i=0; i<2; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
     double EvaluateVar(const Topology &top);
     vec Grad(const Topology &top, int bead);
 
@@ -105,7 +105,7 @@ public:
     IAngle(int bead1, int bead2, int bead3)
         { _beads.resize(3); _beads[0] = bead1; _beads[1] = bead2; _beads[2] = bead3;}
     IAngle(list<int> &beads)
-        { assert(beads.size()<3); _beads.resize(3); for(int i=0; i<3; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
+        { _beads.resize(3); for(int i=0; i<3; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
 
     double EvaluateVar(const Topology &top);
     vec Grad(const Topology &top, int bead);
@@ -122,7 +122,7 @@ public:
     IDihedral(int bead1, int bead2, int bead3, int bead4)
         { _beads.resize(4); _beads[0] = bead1; _beads[1] = bead2; _beads[2] = bead3; _beads[3] = bead4;}
     IDihedral(list<int> &beads)
-        { assert(beads.size()<4); _beads.resize(4); for(int i=0; i<4; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
+        { _beads.resize(4); for(int i=0; i<4; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
    
     double EvaluateVar(const Topology &top);
     vec Grad(const Topology &top, int bead) { assert(false); return vec(0,0,0); } // not implemented


### PR DESCRIPTION
The assertion will cause error whenever the bond contains more than two beads (and angles more than 3) so the following fragment of mapping file isn't anymore correct:

```
    <cg_bonded>
        <bond>
            <name>bond_b0</name>
            <beads>
                A1 B1
                B1 A2
            </beads>
        </bond>
```

this also fails:
https://github.com/votca/csg-tutorials/blob/master/hexane/atomistic/hexane.xml#L29

csg_map: /data/leuven/307/vsc30783/software/votca-mrtheodor/src/csg/include/votca/csg/interaction.h:92: votca::csg::IBond::IBond(std::list<int, std::allocator<int>> &): Assertion `beads.size()<2' failed.
