### PR TITLE
enabling -multidir support for gmx (MPI)

### DIFF
--- a/share/scripts/inverse/csg_table
+++ b/share/scripts/inverse/csg_table
@@ -96,6 +96,10 @@ postadd overwrite postadd_overwrite.sh
 postadd plot postadd_plot.sh
 postadd average postadd_average.sh
 
+# smoothing for updated potential to allow forgetting noise from previous iterations (rdfs)
+# the script is the same as postupd_smooth.sh
+postadd smooth postadd_smooth.sh
+
 #convergence checks
 convergence_check default convergence_check_default.sh
 
@@ -194,6 +198,7 @@ tables jackknife tables_jackknife.pl
 # interface to gromacs
 initstep gromacs initialize_step_genericsim.sh
 run gromacs run_gromacs.sh
+run multidir run_gromacs_multidir.sh
 clean gromacs clean_generic.sh
 presimulation gromacs run_gromacs.sh --pre
 pressure gromacs calc_pressure_gromacs.sh

--- a/share/scripts/inverse/functions_common.sh
+++ b/share/scripts/inverse/functions_common.sh
@@ -642,22 +642,22 @@ add_to_csgshare() { #added an directory to the csg internal search directories
   for dirlist in "$@"; do
     old_IFS="$IFS"
     IFS=":"
-    for dir in $dirlist; do
+    for dir in ${dirlist}; do
       #dir maybe contains $PWD or something
       eval dir="$dir"
-      [[ -d $dir ]] || die "${FUNCNAME[0]}: Could not find scriptdir $dir"
-      dir="$(globalize_dir "$dir")"
+      [[ -d ${dir} ]] || die "${FUNCNAME[0]}: Could not find scriptdir ${dir}"
+      dir="$(globalize_dir "${dir}")"
       if [[ $end = "yes" ]]; then
-        export CSGSHARE="${CSGSHARE}${CSGSHARE:+:}$dir"
-        export PERL5LIB="${PERL5LIB}${PERL5LIB:+:}$dir"
-        export PYTHONPATH="${PYTHONPATH}${PYTHONPATH:+:}$dir"
+        export CSGSHARE="${CSGSHARE}${CSGSHARE:+:}${dir}"
+        export PERL5LIB="${PERL5LIB}${PERL5LIB:+:}${dir}"
+        export PYTHONPATH="${PYTHONPATH}${PYTHONPATH:+:}${dir}"
       else
-        export CSGSHARE="$dir${CSGSHARE:+:}$CSGSHARE"
-        export PERL5LIB="$dir${PERL5LIB:+:}$PERL5LIB"
-        export PYTHONPATH="$dir${PYTHONPATH:+:}$PYTHONPATH"
+        export CSGSHARE="${dir}${CSGSHARE:+:}${CSGSHARE}"
+        export PERL5LIB="${dir}${PERL5LIB:+:}${PERL5LIB}"
+        export PYTHONPATH="${dir}${PYTHONPATH:+:}${PYTHONPATH}"
       fi
     done
-    IFS="$old_IFS"
+    IFS="${old_IFS}"
   done
   check_path_variable CSGSHARE PERL5LIB PYTHONPATH
 }

--- a/share/scripts/inverse/postadd_smooth.sh
+++ b/share/scripts/inverse/postadd_smooth.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+#
+# Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$1" = "--help" ]; then
+cat <<EOF
+${0##*/}, version %version%
+This script implements smoothing of the updated potential (.pot)
+
+Usage: ${0##*/} infile outfile
+EOF
+   exit 0
+fi
+
+[[ -z $1 || -z $2 ]] && die "${0##*/}: Missing arguments"
+
+[ -f "$2" ] && die "${0##*/}: $2 is already there"
+
+name=$(csg_get_interaction_property name)
+tmpfile=$(critical mktemp ${name}.XXX)
+iterations=$(csg_get_interaction_property inverse.post_add_options.smooth.iterations)
+
+critical cp "$1" $tmpfile
+echo "doing $iterations smoothing iterations for interaction $name"
+
+for((i=0;i<$iterations;i++)); do
+  do_external table smooth $tmpfile "$2"
+  critical cp "$2" $tmpfile
+done
+

--- a/share/scripts/inverse/postadd_smooth.sh
+++ b/share/scripts/inverse/postadd_smooth.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+# Copyright 2009-2017 The VOTCA Development Team (http://www.votca.org)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/share/scripts/inverse/run_gromacs.sh
+++ b/share/scripts/inverse/run_gromacs.sh
@@ -28,6 +28,27 @@ EOF
    exit 0
 fi
 
+tasks=$(get_number_tasks)
+
+mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
+
+if [[ ${mdrun_opts} == *multidir* ]]; then
+
+  mdirs=$(echo ${mdrun_opts} | grep -o "sim" | wc -l)
+
+#check mdrun '-multidir' option for consistency
+
+  [[ -n ${mdirs} ]] || die "${0##*/}: mdrun '-multidir' option does not contain directory names including pattern 'sim' (check cg.inverse.gromacs.mdrun.opts)"
+
+  [[ ${mdirs} -gt 1 ]] || die "${0##*/}: mdrun '-multidir' option is set but the number of directories including pattern 'sim' <= 1 (check cg.inverse.gromacs.mdrun.opts)"
+
+  [[ ${mdirs} -le ${tasks} ]] || die "${0##*/}: mdrun '-multidir' option provided presumes the number of separate simulations greater than the number of tasks/threads (check cg.inverse.gromacs.mdrun.opts)"
+
+  do_external run multidir
+  exit
+
+fi
+
 tpr="$(csg_get_property cg.inverse.gromacs.topol)"
 
 mdp="$(csg_get_property cg.inverse.gromacs.mdp)"
@@ -37,7 +58,6 @@ conf="$(csg_get_property cg.inverse.gromacs.conf)"
 [[ -f $conf ]] || die "${0##*/}: gromacs initial configuration file '$conf' not found (make sure it is in cg.inverse.filelist)"
 
 confout="$(csg_get_property cg.inverse.gromacs.conf_out)"
-mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
 
 index="$(csg_get_property cg.inverse.gromacs.index)"
 [[ -f $index ]] || die "${0##*/}: grompp index file '$index' not found (make sure it is in cg.inverse.filelist)"
@@ -133,14 +153,15 @@ else
   echo "${0##*/}: No walltime defined, so no time limitation given to $mdrun"
 fi
 
-#>gmx-5.1 has new handling of bonded tables
-if [[ ${mdrun_opts} != *tableb* ]]; then
+#gmx-5.1 has new handling of bonded tables - is it true only for ver.5.1 or above too???
+#if [[ ${mdrun_opts} != *tableb* ]]; then
+if [[ $(critical ${grompp} -h 2>&1) = *"VERSION 5.1"* && ${mdrun_opts} != *tableb* ]]; then
   tables=
   for i in table_[abd][0-9]*.xvg; do
     [[ -f $i ]] && tables+=" $i"
   done
   if [[ -n ${tables} ]]; then
-	  msg --color blue --to-stderr "Automatically added '-tableb${tables} to mdrun options (add -tableb option to cg.inverse.gromacs.mdrun.opts yourself if this is wrong)"
+    msg --color blue --to-stderr "${0##*/}: Automatically added '-tableb${tables} to mdrun options (add -tableb option to cg.inverse.gromacs.mdrun.opts yourself if this is wrong)"
     mdrun_opts+=" -tableb${tables}"
   fi
 fi

--- a/share/scripts/inverse/run_gromacs.sh
+++ b/share/scripts/inverse/run_gromacs.sh
@@ -154,7 +154,7 @@ else
 fi
 
 #gmx-5.1 has new handling of bonded tables
-    mdrun_opts
+
 if [[ ${mdrun_opts} != *tableb* ]]; then
   tables=
   for i in table_[abd][0-9]*.xvg; do

--- a/share/scripts/inverse/run_gromacs.sh
+++ b/share/scripts/inverse/run_gromacs.sh
@@ -45,7 +45,7 @@ if [[ ${mdrun_opts} == *multidir* ]]; then
   [[ ${mdirs} -le ${tasks} ]] || die "${0##*/}: mdrun '-multidir' option provided presumes the number of separate simulations greater than the number of tasks/threads (check cg.inverse.gromacs.mdrun.opts)"
 
   do_external run multidir
-  exit
+  exit 0
 
 fi
 
@@ -153,9 +153,9 @@ else
   echo "${0##*/}: No walltime defined, so no time limitation given to $mdrun"
 fi
 
-#gmx-5.1 has new handling of bonded tables - is it true only for ver.5.1 or above too???
-#if [[ ${mdrun_opts} != *tableb* ]]; then
-if [[ $(critical ${grompp} -h 2>&1) = *"VERSION 5.1"* && ${mdrun_opts} != *tableb* ]]; then
+#gmx-5.1 has new handling of bonded tables
+    mdrun_opts
+if [[ ${mdrun_opts} != *tableb* ]]; then
   tables=
   for i in table_[abd][0-9]*.xvg; do
     [[ -f $i ]] && tables+=" $i"

--- a/share/scripts/inverse/run_gromacs_multidir.sh
+++ b/share/scripts/inverse/run_gromacs_multidir.sh
@@ -1,0 +1,380 @@
+#! /bin/bash
+#
+# Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ $1 = "--help" ]]; then
+cat <<EOF
+${0##*/}, version %version%
+This script runs a gromacs simulation or pre-simulation
+
+Usage: ${0##*/} [--pre]
+
+Used external packages: gromacs
+
+EOF
+   exit 0
+fi
+
+tasks=$(get_number_tasks)
+
+mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
+
+mdirs=$(echo ${mdrun_opts} | grep -o "sim" | wc -l)
+
+#checks for impossible (due to same checks in run_gromacs.sh)
+
+[[ -n ${mdirs} ]] || die "${0##*/}: mdrun '-multidir' option does not contain directory names including pattern 'sim' (check cg.inverse.gromacs.mdrun.opts)"
+
+[[ ${mdirs} -gt 1 ]] || die "${0##*/}: mdrun '-multidir' option is set but the number of directories including pattern 'sim' <= 1 (check cg.inverse.gromacs.mdrun.opts)"
+
+[[ ${mdirs} -le ${tasks} ]] || die "${0##*/}: mdrun '-multidir' option provided presumes the number of separate simulations greater than the number of tasks/threads (check cg.inverse.gromacs.mdrun.opts)"
+
+echo -e "\nCreating/checking simulation data for ${mdirs} separate simulations (run in parallel)"
+
+#confout="confout.gro"
+confout="$(csg_get_property cg.inverse.gromacs.conf_out)"
+
+#conf="conf.gro"
+conf="$(csg_get_property cg.inverse.gromacs.conf)"
+if [[ -f ${conf}.${it} ]]; then
+    critical cp -f "${conf}.${it}" "$conf"
+fi
+[[ -f $conf ]] || die "${0##*/}: gromacs initial configuration file '$conf' not found (make sure it is in cg.inverse.filelist)"
+
+#mdp="grompp.mdp"
+mdp="$(csg_get_property cg.inverse.gromacs.mdp)"
+if [[ -f ${mdp}.${it} ]]; then
+    critical cp -f "${mdp}.${it}" "$mdp"
+fi
+[[ -f $mdp ]] || die "${0##*/}: gromacs mdp file '$mdp' not found (make sure it is in cg.inverse.filelist)"
+
+#index="index.ndx"
+index="$(csg_get_property cg.inverse.gromacs.index)"
+if [[ -f ${index}.${it} ]]; then
+    critical cp -f "${index}.${it}" "$index"
+fi
+[[ -f $index ]] || die "${0##*/}: grompp index file '$index' not found (make sure it is in cg.inverse.filelist)"
+
+#topol_in="topol.top"
+topol_in="$(csg_get_property cg.inverse.gromacs.topol_in)"
+if [[ -f ${topol_in}.${it} ]]; then
+    critical cp -f "${topol_in}.${it}" "$topol_in"
+fi
+[[ -f $topol_in ]] || die "${0##*/}: grompp text topol file '$topol_in' not found (make sure it is in cg.inverse.filelist)"
+
+#traj="traj.xtc"
+traj="$(csg_get_property cg.inverse.gromacs.traj)"
+
+#checkpoint="state.cpt"
+checkpoint="$(csg_get_property cg.inverse.gromacs.mdrun.checkpoint)"
+
+#tpr="topol.tpr"
+tpr="$(csg_get_property cg.inverse.gromacs.topol)"
+
+#mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
+grompp_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.grompp.opts)"
+
+#grompp="gmx grompp"
+grompp="$(csg_get_property cg.inverse.gromacs.grompp.bin)"
+[[ -n "$(type -p ${grompp})" ]] && echo "using grompp binary '${grompp}'" || die "${0##*/}: grompp binary '${grompp}' not found (override by cg.inverse.gromacs.grompp.bin)"
+
+if is_done "Simtasks"; then
+
+    echo -e "\nAll Simulation tasks done - skipping\n"
+
+else
+
+    for ((it=0;it<mdirs;it++)); do
+	this_dir="sim_${it}"
+
+	if [[ -d $this_dir ]]; then
+
+	    cd $this_dir || die "${0##*/}: cd $this_dir failed"
+
+	    if is_done "Simulation"; then 
+		echo -e "\nSimulation task ${it} done - skipping\n"
+		cd ../
+		continue; 
+	    fi
+
+	    cd ../
+
+	else
+	    echo -e "\nSimulation task $it created at $(date)\n"
+	    mkdir -p $this_dir || die "${0##*/}: mkdir -p $this_dir failed (unfinished simulation exists?)"
+	fi
+
+	cd $this_dir || die "${0##*/}: cd $this_dir failed"
+
+	filelist="$(csg_get_property --allow-empty cg.inverse.filelist)"
+
+	if is_done "Filecopy"; then
+        #check for needed files 
+	    echo "Filecopy already done"
+	    for f in $filelist; do
+
+		[[ -f $f ]] || cp_from_main_dir "$f"
+
+		echo Comparing "$(get_main_dir)/$f" "$f"
+		[[ -z $(type -p cmp) ]] && echo "${0##*/}: program 'cmp' not found, comparision skipped" && continue
+
+		cmp "$(get_main_dir)/$f" "$f" && echo "Unchanged" || \
+		msg --color blue --to-stderr "${0##*/}: WARNING: file '$f' in the main dir was changed since the last execution, this will have no effect on the current iteration, to take effect remove the current iteration ('${this_dir##*/}')"
+
+	    done
+	else
+        #get needed files 
+	    echo "Copying the needed files"
+	    [[ -n ${filelist} ]] && cp_from_main_dir "$filelist"
+
+	    mark_done "Filecopy"
+	fi
+
+	if [[ $1 != "--pre" ]]; then
+        #in a presimulation usually do care about traj and temperature
+	   check_temp || die "${0##*/}: check of tempertures failed"
+	   if [[ ${traj} == *.xtc ]]; then
+	      [[ $(get_simulation_setting nstxtcout 0) -eq 0 ]] && die "${0##*/}: trajectory type (cg.inverse.gromacs.traj) is '${traj##*.}', but nstxtcout is 0 in $mdp. Please check the setting again and remove the current step."
+	   elif [[ ${traj} == *.trr ]]; then
+		[[ $(get_simulation_setting nstxout 0) -eq 0 ]] && die "${0##*/}: trajectory type (cg.inverse.gromacs.traj) is '${traj##*.}', but nstxout is 0 in $mdp. Please check the setting again and remove the current step."
+	   else
+	       die "${0##*/}: error trajectory type '${traj##*.}' (ending from '${traj}') is not supported"
+	   fi
+	fi
+
+        [[ -f ${checkpoint} ]] && echo "using checkpoint file '${checkpoint}'"
+
+#support for older mdp files (before ver.5.0): 
+#'cutoff-scheme = Verlet' is the default for Gromacs 5.0, but does not work with tabulated interactions
+#XXX is returned if cutoff-scheme is not found in mdp file
+#	if [[ $(critical ${grompp} -h 2>&1) = *"VERSION 5.0"* && $(get_simulation_setting cutoff-scheme XXX) = XXX ]]; then
+
+	if [[ $(critical ${grompp} -h 2>&1) = *"VERSION 5"* && $(get_simulation_setting cutoff-scheme XXX) = XXX ]]; then
+	   echo "cutoff-scheme = group" >> $mdp
+	   msg --color blue --to-stderr "Automatically added 'cutoff-scheme = Group' to $mdp, tabulated interactions only work with Group cutoff-scheme!"
+	fi
+
+	critical cp ../tab*xvg ./
+
+#see if we can run grompp again as checksum of tpr does not appear in the checkpoint
+
+#not using grompp_log, as it seems undefiend by default, so errors (if any) are missing from log/err files
+
+	critical ${grompp} -n "${index}" -f "${mdp}" -p "$topol_in" -o "$tpr" -c "${conf}" ${grompp_opts} 2>&1 
+#| grompp_log "${grompp} -n "${index}" -f "${mdp}" -p "$topol_in" -o "$tpr" -c "${conf}" ${grompp_opts}"
+
+	[[ -f $tpr ]] || die "${0##*/}: gromacs tpr file '$tpr' not found after runing grompp"
+
+	cd ../
+
+#done preparation of simulation task - for ((it=0;it<mdirs;it++)); do ...
+    done
+
+    #should be done above
+    #mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
+
+    mdrun="$(csg_get_property cg.inverse.gromacs.mdrun.command)"
+    #no check for mdrun, because mdrun_mpi could maybe exist only on compute nodes
+
+    if [[ -n $CSGENDING ]]; then
+    #seconds left for the run
+	wall_h=$(( $CSGENDING - $(get_time) ))
+    #convert to hours
+	wall_h=$(csg_calc $wall_h / 3600 )
+	echo "${0##*/}: Setting $mdrun maxh option to $wall_h (hours)"
+	mdrun_opts="-cpi $checkpoint -maxh $wall_h ${mdrun_opts}"
+    else
+	echo "${0##*/}: No walltime defined, so no time limitation given to $mdrun"
+    fi
+
+    if [[ -e ${traj} ]]; then
+
+	echo "Overall (combined) trajectory found - skipping simulation"
+
+    else
+
+#not using gromacs_log, as it seems undefiend by default, so errors (if any) are missing from log/err files
+
+	critical $mdrun -s "${tpr}" -c "${confout}" -o "${traj%.*}".trr -x "${traj%.*}".xtc ${mdrun_opts} 2>&1 
+#| gromacs_log "$mdrun -s "${tpr}" -c "${confout}" -o "${traj%.*}".trr -x "${traj%.*}".xtc ${mdrun_opts}"
+
+        simok="YES"
+        for ((it=0;it<mdirs;it++)); do
+	   this_dir="sim_${it}"
+
+	   critical cd "${this_dir}"
+
+	   if [[ ${simok} == "YES" && -f ${confout} ]]; then
+              [[ -z "$(sed -n '/[nN][aA][nN]/p' ${confout})" ]] || { simok="NO"; msg --color blue --to-stderr "${0##*/}: There is a nan in '${this_dir}/${confout}', this seems to be wrong!"; }
+           else
+              simok="NO"
+              msg --color blue --to-stderr "${0##*/}: Gromacs output file ${this_dir}/${confout} not found!"
+           fi
+
+	   if [[ ${simok} == "YES" && -f ${traj} ]]; then 
+              mark_done "Simulation" 
+           else
+              simok="NO" 
+              msg --color blue --to-stderr "${0##*/}: Trajectory file '${this_dir}/${traj}' not found!"
+           fi
+
+	   critical cd ../
+
+        done
+
+	if [[ ${simok} == "YES" ]]; then 
+           mark_done "Simtasks"
+        else 
+           die "${0##*/}: Multi-task simulation failed (try to restart)."
+        fi
+    fi
+fi
+
+is_done "Simtasks" || die "${0##*/}: Multi-task simulation appears unfinished (try to restart)."
+
+#trjcat="gmx trjcat"
+trjcat="$(csg_get_property cg.inverse.gromacs.trjcat)"
+[[ -n "$(type -p ${trjcat})" ]] && echo "using trjcat binary '${trjcat}'" || die "${0##*/}: trjcat binary '${trjcat}' not found (override by cg.inverse.gromacs.trjcat)"
+
+if is_done "Trajectory"; then
+
+    echo -e "\nTrajectory assembly done for all - skipping\n"
+
+elif  [[ -f "${traj}" ]]; then
+
+    echo -e "\nFound combined trajectory - checking for completeness\n"
+
+    for ((it=0;it<mdirs;it++)); do
+	this_dir="sim_${it}"
+
+	critical cd "${this_dir}"
+
+	if is_done "Trajectory"; then
+
+	  echo "Trajectory in ${this_dir} has been appended previously - skipping\n"
+
+	elif is_done "Simulation"; then
+
+          if [[ -f "${traj}" ]]; then
+
+	     [[ -z "$(sed -n '/[nN][aA][nN]/p' ${confout})" ]] || die "${0##*/}: There is a nan in '${this_dir}'/'${confout}', this seems to be wrong."
+
+	     critical echo "0" | ${trjcat} -f ../"${traj}" "${traj}" -o ../"${traj}" -n "$index" -cat
+
+	     mark_done "Trajectory"
+
+             cleanlist="$(csg_get_property --allow-empty cg.inverse.cleanlist)"
+	     if [[ -n ${cleanlist} ]]; then
+	        msg "Cleaning up files in ${this_dir}: $cleanlist"
+	        rm -f ${cleanlist}
+	     fi
+
+	  else
+	     die "${0##*/}: No trajectory '${traj}' found in '${this_dir}' (simulation failed?)"
+	  fi
+
+	else
+	  die "${0##*/}: Simulation not finished in '${this_dir}' (simulation failed?)"
+	fi
+
+	cleanlist="$(csg_get_property --allow-empty cg.inverse.cleanlist)"
+	if [[ -n ${cleanlist} ]]; then
+	   msg "Cleaning up files in ${this_dir}: $cleanlist"
+	   rm -f ${cleanlist}
+	fi
+
+	critical cd ../
+
+    done
+
+    mark_done "Trajectory"
+    mark_done "Simulation"
+
+else
+
+    echo -e "\nCombined trajectory not found - checking for simulation results\n"
+
+    if [[ -f "sim_0/${traj}" ]]; then
+
+	critical cd sim_0
+
+        if [[ -f ${confout} ]]; then
+	   [[ -z "$(sed -n '/[nN][aA][nN]/p' ${confout})" ]] || msg "${0##*/}: There is a nan in sim_0/'${confout}', this seems to be wrong."
+        else
+	   msg "${0##*/}: Found trajectory file 'sim_0/${traj}' but not configuration file 'sim_0/${confout}'."
+        fi
+
+        is_done Simulation || mark_done "Simulation"
+
+	critical cp -f "$confout" ../
+	critical cp -f "${traj}" ../
+
+	mark_done "Trajectory"
+
+	critical cd ../
+
+	for ((it=1;it<mdirs;it++)); do
+	   this_dir="sim_${it}"
+
+           if [[ -f "${this_dir}/${traj}" ]]; then
+
+	      critical cd "${this_dir}"
+
+              if [[ -f ${confout} ]]; then
+	         [[ -z "$(sed -n '/[nN][aA][nN]/p' ${confout})" ]] || msg "${0##*/}: There is a nan in '${this_dir}/${confout}', this seems to be wrong."
+              else
+	         msg "${0##*/}: Found trajectory file '${this_dir}/${traj}' but not configuration file '${this_dir}/${confout}'."
+              fi
+
+              critical echo "0" | ${trjcat} -f ../"${traj}" "${traj}" -o ../"${traj}" -n "$index" -cat
+
+	      mark_done "Trajectory"
+
+	      cleanlist="$(csg_get_property --allow-empty cg.inverse.cleanlist)"
+	      if [[ -n ${cleanlist} ]]; then
+	         msg "Cleaning up files in ${this_dir}: $cleanlist"
+	         rm -f ${cleanlist}
+	      fi
+
+	      critical cd ../
+
+	   else
+	      die "${0##*/}: No trajectory '${traj}' found in '${this_dir}' (simulation failed?)"
+	   fi
+
+	done
+
+        #copying critial output files to current step directory to be able to analyse
+	critical cp -fv sim_0/*edr sim_0/*cpt sim_0/*.tpr ./
+
+	critical cd sim_0
+
+	cleanlist="$(csg_get_property --allow-empty cg.inverse.cleanlist)"
+	if [[ -n ${cleanlist} ]]; then
+	   msg "Cleaning up files in sim_0: $cleanlist"
+	   rm -f ${cleanlist}
+	fi
+
+	critical cd ../
+
+	mark_done "Trajectory"
+	mark_done "Simulation"
+
+    else
+	die "${0##*/}: No trajectory '${traj}' found in sim_0 (simulation failed?)"
+    fi
+
+fi

--- a/share/xml/csg_defaults.xml
+++ b/share/xml/csg_defaults.xml
@@ -244,6 +244,9 @@
       <traj>traj.xtc
         <DESC> Gromacs trajectory file to use</DESC>
       </traj>
+      <trjcat>gmx trjcat
+        <DESC> Gromacs trajectory concatenation uitility</DESC>
+      </trjcat>
     </gromacs>
     <hoomd-blue>
       <command>hoomd


### PR DESCRIPTION
enabling -multidir option for gmx mdrun (MPI) via extra script run_gromacs_multidir.sh which is called from run_gromacs; it deals with all the additional input and proper restarts after errors (checked in IBI and IMC iterations); this necessitated slight amendements in other files (3, 5 in total)

The scripts allow to run mdrun (MPI) with '-multidir' option, which can be used to reduce the wall-time per iteration (IBI/IMC) while accumulating better stats than otherwise, due to different initial configurations and, hence, diverse trajectories. This is especially helpful to improve convergence of IMC. As a matter of fact, the IMC solver may take longer to run in between iterations than the MD simulation. Same setup with different starting points (but at the same temperature) can improve convergence of IBI as well. There is perhaps very little benefit for uniform and homogeneous systems. 

For reference in Gromacs documentation (2016.3), see here: http://manual.gromacs.org/documentation/2016.3/user-guide/mdrun-features.html