### PR TITLE
Allow to override build date

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,3 +1,4 @@
+string(TIMESTAMP VOTCA_DATE "%Y-%m-%d %H:%M:%S" UTC)
 configure_file(help2t2t.in ${CMAKE_CURRENT_BINARY_DIR}/help2t2t.out @ONLY)
 add_custom_target(help2t2t_build DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/help2t2t)
 add_custom_command(OUTPUT help2t2t ALL COMMAND ${CMAKE_COMMAND}

--- a/scripts/help2t2t.in
+++ b/scripts/help2t2t.in
@@ -72,7 +72,7 @@ fi
 cat <<EOF
 $prog
 Version: $version
-$(date)
+@VOTCA_DATE@
 
 = NAME =
 


### PR DESCRIPTION
that ends up in man page headers
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call only works with GNU date.

An alternative approach that also works with BSD date is to use
`date -u -r CHANGELOG.md`