### PR TITLE
Updated call to HistogramNew Initialize() max value was inappropriate

### DIFF
--- a/src/tools/csg_stat_imc.cc
+++ b/src/tools/csg_stat_imc.cc
@@ -137,9 +137,9 @@ Imc::interaction_t *Imc::AddInteraction(Property *p)
     i->_p=p;
     
     // initialize the current and average histogram
-    int n = (int)((i->_max - i->_min) / i->_step + 1.000000001);
+    int n = static_cast<int>((i->_max - i->_min) / i->_step + 1.000000001);
 
-    i->_average.Initialize(i->_min, i->_max+i->_step, n);
+    i->_average.Initialize(i->_min, i->_max, n);
     
     return i;
 }


### PR DESCRIPTION
According to netbeans this is the only place where this update to HistogramNew will affect anything in VOTCA. 

https://github.com/votca/tools/pull/30