### PR TITLE
Bug interaction class does not define initial values

### DIFF
--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -83,7 +83,7 @@ public:
   virtual vec Grad(const Topology &top, int bead) = 0;
   int BeadCount() { return _beads.size(); }
   int getBeadId(int bead) {
-    assert(bead > -1 && bead < _beads.size());
+    assert(bead > -1 && boost::lexical_cast<size_t>(bead) < _beads.size());
     return _beads[bead];
   }
 

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -50,22 +50,25 @@ public:
     string getName() const { return _name; }
         
     void setGroup(const string &group) { _group = group; RebuildName(); }
-    const string &getGroup() const { return _group; }
+    const string &getGroup() const { assert(_group.compare("")!=0); return _group; }
 
     // the group id is set by topology, when interaction is added to it
     // \todo if the group name is changed later, group id should be updated by topology
-    int getGroupId() { return _group_id; }
+    int getGroupId() { assert(_group_id!=-1); return _group_id; }
     void setGroupId(int id) { _group_id = id; }
 
     void setIndex(const int &index) { _index = index; RebuildName(); }
-    const int &getIndex() const { return _index; }
+    const int &getIndex() const { assert(_index!=-1); return _index; }
     
     void setMolecule(const int &mol) { _mol = mol; RebuildName(); }
-    const int &getMolecule() const { return _mol; }
+    const int &getMolecule() const { assert(_mol!=-1); return _mol; }
     
     virtual vec Grad(const Topology &top, int bead) = 0;
     int BeadCount() { return _beads.size(); }
-    int getBeadId(int bead) { return _beads[bead]; }
+    int getBeadId(int bead) { 
+      assert(bead>-1 && bead<_beads.size());
+      return _beads[bead]; 
+    }
     
 protected:
     int _index;
@@ -81,9 +84,14 @@ protected:
 inline void Interaction::RebuildName()
 {
     stringstream s;
-    if(_mol!=-1) s << _mol+1;
-    if(_group.compare("")==0) s << ":" << _group;
-    if(_index!=-1) s << ":" << _index+1;
+    if(_mol!=-1) s << "molecule " << _mol+1;
+    if(_group.compare("")==0) {
+      s << ":" << _group;
+      if(_group_id!=-1){
+        s << " " << _group_id;
+      }
+    }
+    if(_index!=-1) s << ":bond " << _index+1;
     _name = s.str();
 }
 

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -270,15 +270,15 @@ inline vec IDihedral::Grad(const Topology &top, int bead) {
       sign;
   switch (bead) {
   case (0): { //
-    returnvec0 = acos_prime * (
-      (n2 * (v2 ^ e0)) / (abs(n1) * abs(n2)) -
-      ((n1 * n2) * (n1 * (v2 ^ e0))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
-    returnvec1 = acos_prime * (
-      (n2 * (v2 ^ e1)) / (abs(n1) * abs(n2)) -
-      ((n1 * n2) * (n1 * (v2 ^ e1))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
-    returnvec2 = acos_prime * (
-      (n2 * (v2 ^ e2)) / (abs(n1) * abs(n2)) -
-      ((n1 * n2) * (n1 * (v2 ^ e2))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec0 = acos_prime * ((n2 * (v2 ^ e0)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n1 * (v2 ^ e0))) /
+                                   (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec1 = acos_prime * ((n2 * (v2 ^ e1)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n1 * (v2 ^ e1))) /
+                                   (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec2 = acos_prime * ((n2 * (v2 ^ e2)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n1 * (v2 ^ e2))) /
+                                   (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
     returnvec.setX(returnvec0);
     returnvec.setY(returnvec1);
     returnvec.setZ(returnvec2);

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,15 @@
  */
 
 #ifndef _VOTCA_CSG_INTERACTION_H
-#define	_VOTCA_CSG_INTERACTION_H
+#define _VOTCA_CSG_INTERACTION_H
 
-#include <string>
-#include <sstream>
-#include "topology.h"
 #include "bead.h"
+#include "topology.h"
+#include <sstream>
+#include <string>
 
-namespace votca { namespace csg {
+namespace votca {
+namespace csg {
 using namespace votca::tools;
 using namespace std;
 
@@ -34,80 +35,105 @@ using namespace std;
 
     \todo double names/groups right, add molecules!!
 */
-class Interaction
-{
+class Interaction {
 public:
-    Interaction() :
-      _index(-1),
-      _group(""),
-      _group_id(-1),
-      _name(""),
-      _mol(-1) {};
+  Interaction() : _index(-1), _group(""), _group_id(-1), _name(""), _mol(-1){};
 
-    virtual ~Interaction() { }
-    virtual double EvaluateVar(const Topology &top) = 0;
-        
-    string getName() const { return _name; }
-        
-    void setGroup(const string &group) { _group = group; RebuildName(); }
-    const string &getGroup() const { assert(_group.compare("")!=0); return _group; }
+  virtual ~Interaction() {}
+  virtual double EvaluateVar(const Topology &top) = 0;
 
-    // the group id is set by topology, when interaction is added to it
-    // \todo if the group name is changed later, group id should be updated by topology
-    int getGroupId() { assert(_group_id!=-1); return _group_id; }
-    void setGroupId(int id) { _group_id = id; }
+  string getName() const { return _name; }
 
-    void setIndex(const int &index) { _index = index; RebuildName(); }
-    const int &getIndex() const { assert(_index!=-1); return _index; }
-    
-    void setMolecule(const int &mol) { _mol = mol; RebuildName(); }
-    const int &getMolecule() const { assert(_mol!=-1); return _mol; }
-    
-    virtual vec Grad(const Topology &top, int bead) = 0;
-    int BeadCount() { return _beads.size(); }
-    int getBeadId(int bead) { 
-      assert(bead>-1 && bead<_beads.size());
-      return _beads[bead]; 
-    }
-    
+  void setGroup(const string &group) {
+    _group = group;
+    RebuildName();
+  }
+  const string &getGroup() const {
+    assert(_group.compare("") != 0);
+    return _group;
+  }
+
+  // the group id is set by topology, when interaction is added to it
+  // \todo if the group name is changed later, group id should be updated by
+  // topology
+  int getGroupId() {
+    assert(_group_id != -1);
+    return _group_id;
+  }
+  void setGroupId(int id) { _group_id = id; }
+
+  void setIndex(const int &index) {
+    _index = index;
+    RebuildName();
+  }
+  const int &getIndex() const {
+    assert(_index != -1);
+    return _index;
+  }
+
+  void setMolecule(const int &mol) {
+    _mol = mol;
+    RebuildName();
+  }
+  const int &getMolecule() const {
+    assert(_mol != -1);
+    return _mol;
+  }
+
+  virtual vec Grad(const Topology &top, int bead) = 0;
+  int BeadCount() { return _beads.size(); }
+  int getBeadId(int bead) {
+    assert(bead > -1 && bead < _beads.size());
+    return _beads[bead];
+  }
+
 protected:
-    int _index;
-    string _group;
-    int _group_id;
-    string _name;
-    int _mol;
-    vector<int> _beads;
-    
-    void RebuildName();
+  int _index;
+  string _group;
+  int _group_id;
+  string _name;
+  int _mol;
+  vector<int> _beads;
+
+  void RebuildName();
 };
 
-inline void Interaction::RebuildName()
-{
-    stringstream s;
-    if(_mol!=-1) s << "molecule " << _mol;
-    if(!_group.empty()) {
-      s << ":" << _group;
-      if(_group_id!=-1){
-        s << " " << _group_id;
-      }
+inline void Interaction::RebuildName() {
+  stringstream s;
+  if (_mol != -1)
+    s << "molecule " << _mol;
+  if (!_group.empty()) {
+    s << ":" << _group;
+    if (_group_id != -1) {
+      s << " " << _group_id;
     }
-    if(_index!=-1) s << ":index " << _index;
-    _name = s.str();
+  }
+  if (_index != -1)
+    s << ":index " << _index;
+  _name = s.str();
 }
 
 /**
     \brief bond interaction
 */
-class IBond : public Interaction
-{
+class IBond : public Interaction {
 public:
-    IBond(int bead1, int bead2)
-        { _beads.resize(2); _beads[0] = bead1; _beads[1] = bead2; }
+  IBond(int bead1, int bead2) {
+    _beads.resize(2);
+    _beads[0] = bead1;
+    _beads[1] = bead2;
+  }
 
-    IBond(list<int> &beads)
-        { assert(beads.size()>=2); _beads.resize(2); for(int i=0; i<2; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
-    double EvaluateVar(const Topology &top);
-    vec Grad(const Topology &top, int bead);
+  IBond(list<int> &beads) {
+    assert(beads.size() >= 2);
+    _beads.resize(2);
+    for (int i = 0; i < 2; ++i) {
+      _beads[i] = beads.front();
+      beads.pop_front();
+    }
+  }
+  double EvaluateVar(const Topology &top);
+  vec Grad(const Topology &top, int bead);
 
 private:
 };
@@ -115,16 +141,25 @@ private:
 /**
     \brief angle interaction
 */
-class IAngle : public Interaction
-{
+class IAngle : public Interaction {
 public:
-    IAngle(int bead1, int bead2, int bead3)
-        { _beads.resize(3); _beads[0] = bead1; _beads[1] = bead2; _beads[2] = bead3;}
-    IAngle(list<int> &beads)
-        { assert(beads.size()>=3); _beads.resize(3); for(int i=0; i<3; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
+  IAngle(int bead1, int bead2, int bead3) {
+    _beads.resize(3);
+    _beads[0] = bead1;
+    _beads[1] = bead2;
+    _beads[2] = bead3;
+  }
+  IAngle(list<int> &beads) {
+    assert(beads.size() >= 3);
+    _beads.resize(3);
+    for (int i = 0; i < 3; ++i) {
+      _beads[i] = beads.front();
+      beads.pop_front();
+    }
+  }
 
-    double EvaluateVar(const Topology &top);
-    vec Grad(const Topology &top, int bead);
+  double EvaluateVar(const Topology &top);
+  vec Grad(const Topology &top, int bead);
 
 private:
 };
@@ -132,132 +167,202 @@ private:
 /**
     \brief dihedral interaction
 */
-class IDihedral : public Interaction
-{
+class IDihedral : public Interaction {
 public:
-    IDihedral(int bead1, int bead2, int bead3, int bead4)
-        { _beads.resize(4); _beads[0] = bead1; _beads[1] = bead2; _beads[2] = bead3; _beads[3] = bead4;}
-    IDihedral(list<int> &beads)
-        { assert(beads.size()>=4); _beads.resize(4); for(int i=0; i<4; ++i) { _beads[i] = beads.front(); beads.pop_front(); }}
-   
-    double EvaluateVar(const Topology &top);
-    vec Grad(const Topology &top, int bead);
+  IDihedral(int bead1, int bead2, int bead3, int bead4) {
+    _beads.resize(4);
+    _beads[0] = bead1;
+    _beads[1] = bead2;
+    _beads[2] = bead3;
+    _beads[3] = bead4;
+  }
+  IDihedral(list<int> &beads) {
+    assert(beads.size() >= 4);
+    _beads.resize(4);
+    for (int i = 0; i < 4; ++i) {
+      _beads[i] = beads.front();
+      beads.pop_front();
+    }
+  }
+
+  double EvaluateVar(const Topology &top);
+  vec Grad(const Topology &top, int bead);
 
 private:
 };
 
-inline double IBond::EvaluateVar(const Topology &top)
-{
-    return abs(top.getDist(_beads[0], _beads[1]));
+inline double IBond::EvaluateVar(const Topology &top) {
+  return abs(top.getDist(_beads[0], _beads[1]));
 }
 
-inline vec IBond::Grad(const Topology &top, int bead)
-{
-    vec r = top.getDist(_beads[0], _beads[1]); 
-    r.normalize();
-    return (bead == 0) ? -r : r;
-}
-    
-inline double IAngle::EvaluateVar(const Topology &top)
-{
-    vec v1(top.getDist(_beads[1], _beads[0]));
-    vec v2(top.getDist(_beads[1], _beads[2]));
-    return  acos(v1*v2/sqrt((v1*v1) * (v2*v2)));    
+inline vec IBond::Grad(const Topology &top, int bead) {
+  vec r = top.getDist(_beads[0], _beads[1]);
+  r.normalize();
+  return (bead == 0) ? -r : r;
 }
 
-inline vec IAngle::Grad(const Topology &top, int bead)
-{
-    vec v1(top.getDist(_beads[1], _beads[0]));
-    vec v2(top.getDist(_beads[1], _beads[2]));
-    
-    double acos_prime = 1.0 / (sqrt(1 - (v1*v2) * (v1*v2)/( abs(v1) * abs(v2) * abs(v1) * abs(v2) ) ));
-    switch (bead) {
-        case (0): return acos_prime * (-v2 / ( abs(v1)*abs(v2) ) +  (v1*v2) * v1 / ( abs(v2)*abs(v1)*abs(v1)*abs(v1) ) ); break;
-        case (1): return acos_prime * ( (v1+v2)/(abs(v1) * abs(v2)) - (v1 * v2) * ((v2*v2) * v1 + (v1*v1) * v2 ) / ( abs(v1)*abs(v1)*abs(v1)*abs(v2)*abs(v2)*abs(v2) ) ); break;
-        case (2): return acos_prime * (-v1 / ( abs(v1)*abs(v2) ) +  (v1*v2) * v2 / ( abs(v1)*abs(v2)*abs(v2)*abs(v2) ) ); break;
-    }
-    // should never reach this
-    assert(false);
-    return vec(0,0,0);
+inline double IAngle::EvaluateVar(const Topology &top) {
+  vec v1(top.getDist(_beads[1], _beads[0]));
+  vec v2(top.getDist(_beads[1], _beads[2]));
+  return acos(v1 * v2 / sqrt((v1 * v1) * (v2 * v2)));
 }
 
-inline double IDihedral::EvaluateVar(const Topology &top)
-{
-    vec v1(top.getDist(_beads[0], _beads[1]));
-    vec v2(top.getDist(_beads[1], _beads[2]));
-    vec v3(top.getDist(_beads[2], _beads[3]));
-    vec n1, n2;
-    n1 = v1^v2; // calculate the normal vector
-    n2 = v2^v3; // calculate the normal vector
-    double sign = (v1*n2 < 0) ? -1 : 1;
-    return sign*acos(n1*n2/sqrt((n1*n1) * (n2*n2)));
+inline vec IAngle::Grad(const Topology &top, int bead) {
+  vec v1(top.getDist(_beads[1], _beads[0]));
+  vec v2(top.getDist(_beads[1], _beads[2]));
+
+  double acos_prime =
+      1.0 /
+      (sqrt(1 -
+            (v1 * v2) * (v1 * v2) / (abs(v1) * abs(v2) * abs(v1) * abs(v2))));
+  switch (bead) {
+  case (0):
+    return acos_prime *
+           (-v2 / (abs(v1) * abs(v2)) +
+            (v1 * v2) * v1 / (abs(v2) * abs(v1) * abs(v1) * abs(v1)));
+    break;
+  case (1):
+    return acos_prime *
+           ((v1 + v2) / (abs(v1) * abs(v2)) -
+            (v1 * v2) * ((v2 * v2) * v1 + (v1 * v1) * v2) /
+                (abs(v1) * abs(v1) * abs(v1) * abs(v2) * abs(v2) * abs(v2)));
+    break;
+  case (2):
+    return acos_prime *
+           (-v1 / (abs(v1) * abs(v2)) +
+            (v1 * v2) * v2 / (abs(v1) * abs(v2) * abs(v2) * abs(v2)));
+    break;
+  }
+  // should never reach this
+  assert(false);
+  return vec(0, 0, 0);
 }
 
-inline vec IDihedral::Grad(const Topology &top, int bead)
-{
-    vec v1(top.getDist(_beads[0], _beads[1]));
-    vec v2(top.getDist(_beads[1], _beads[2]));
-    vec v3(top.getDist(_beads[2], _beads[3]));
-    vec n1, n2;
-    n1 = v1^v2; // calculate the normal vector
-    n2 = v2^v3; // calculate the normal vector
-    double sign = (v1*n2 < 0) ? -1 : 1;
-    vec returnvec; //vector to return
-    double returnvec0,returnvec1,returnvec2; //components of the return vector    
-    vec e0(1,0,0); //unit vector pointing in x-direction
-    vec e1(0,1,0); //unit vector pointing in y-direction
-    vec e2(0,0,1); //unit vector pointing in z-direction
-    
-    
-    double acos_prime = ( - 1.0 / (sqrt(1 - (n1*n2) * (n1*n2)/( abs(n1) * abs(n2) * abs(n1) * abs(n2) ) )) ) * sign;
-    switch (bead) {
-        case (0): { //
-                    returnvec0 = acos_prime * ( ( n2*(v2^e0) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n1*(v2^e0) ) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) );
-                    returnvec1 = acos_prime * ( ( n2*(v2^e1) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n1*(v2^e1) ) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) );
-                    returnvec2 = acos_prime * ( ( n2*(v2^e2) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n1*(v2^e2) ) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) );
-                    returnvec.setX(returnvec0);
-                    returnvec.setY(returnvec1);
-                    returnvec.setZ(returnvec2);
-                    return returnvec;
-                    break;
-        }             
-        case (1): { //
-                    returnvec0 = acos_prime * ( ( n1*(v3^e0)+n2*((e0^v1)+(e0^v2)) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*((e0^v1)+(e0^v2)) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*(v3^e0) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec1 = acos_prime * ( ( n1*(v3^e1)+n2*((e1^v1)+(e1^v2)) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*((e1^v1)+(e1^v2)) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*(v3^e1) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec2 = acos_prime * ( ( n1*(v3^e2)+n2*((e2^v1)+(e2^v2)) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*((e2^v1)+(e2^v2)) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*(v3^e2) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec.setX(returnvec0);
-                    returnvec.setY(returnvec1);
-                    returnvec.setZ(returnvec2);
-                    return returnvec;
-                    break;
-        } ;
-        case (2): { //
-                    returnvec0 = acos_prime * ( ( n1*((e0^v2)+(e0^v3))+n2*(v1^e0) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*(v1^e0) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*((e0^v2)+(e0^v3)) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec1 = acos_prime * ( ( n1*((e1^v2)+(e1^v3))+n2*(v1^e1) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*(v1^e1) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*((e1^v2)+(e1^v3)) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec2 = acos_prime * ( ( n1*((e2^v2)+(e2^v3))+n2*(v1^e2) )/( abs(n1)*abs(n2) ) - ( (n1*n2)* ( ( n1*(v1^e2) )/( abs(n1)*abs(n1)*abs(n1)*abs(n2) ) + ( n2*((e2^v2)+(e2^v3)) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) ) ) );
-                    returnvec.setX(returnvec0);
-                    returnvec.setY(returnvec1);                    
-                    returnvec.setZ(returnvec2);
-                    return returnvec;
-                    break;
-        } ;
-        case (3): { //
-                    returnvec0 = acos_prime * ( ( n1*(v2^e0) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n2*(v2^e0) ) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) );
-                    returnvec1 = acos_prime * ( ( n1*(v2^e1) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n2*(v2^e1) ) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) );
-                    returnvec2 = acos_prime * ( ( n1*(v2^e2) )/( abs(n1)*abs(n2) ) - ( (n1*n2)*( n2*(v2^e2) ) )/( abs(n1)*abs(n2)*abs(n2)*abs(n2) ) );
-                    returnvec.setX(returnvec0);
-                    returnvec.setY(returnvec1);
-                    returnvec.setZ(returnvec2);
-                    return returnvec;
-                    break;
-        } ;
-    }
-    // should never reach this
-    assert(false);
-    return vec(0,0,0);
+inline double IDihedral::EvaluateVar(const Topology &top) {
+  vec v1(top.getDist(_beads[0], _beads[1]));
+  vec v2(top.getDist(_beads[1], _beads[2]));
+  vec v3(top.getDist(_beads[2], _beads[3]));
+  vec n1, n2;
+  n1 = v1 ^ v2; // calculate the normal vector
+  n2 = v2 ^ v3; // calculate the normal vector
+  double sign = (v1 * n2 < 0) ? -1 : 1;
+  return sign * acos(n1 * n2 / sqrt((n1 * n1) * (n2 * n2)));
 }
 
-}}
+inline vec IDihedral::Grad(const Topology &top, int bead) {
+  vec v1(top.getDist(_beads[0], _beads[1]));
+  vec v2(top.getDist(_beads[1], _beads[2]));
+  vec v3(top.getDist(_beads[2], _beads[3]));
+  vec n1, n2;
+  n1 = v1 ^ v2; // calculate the normal vector
+  n2 = v2 ^ v3; // calculate the normal vector
+  double sign = (v1 * n2 < 0) ? -1 : 1;
+  vec returnvec;                             // vector to return
+  double returnvec0, returnvec1, returnvec2; // components of the return vector
+  vec e0(1, 0, 0); // unit vector pointing in x-direction
+  vec e1(0, 1, 0); // unit vector pointing in y-direction
+  vec e2(0, 0, 1); // unit vector pointing in z-direction
 
-#endif	// _VOTCA_CSG_INTERACTION_H 
+  double acos_prime =
+      (-1.0 / (sqrt(1 -
+                    (n1 * n2) * (n1 * n2) /
+                        (abs(n1) * abs(n2) * abs(n1) * abs(n2))))) *
+      sign;
+  switch (bead) {
+  case (0): { //
+    returnvec0 = acos_prime * (
+      (n2 * (v2 ^ e0)) / (abs(n1) * abs(n2)) -
+      ((n1 * n2) * (n1 * (v2 ^ e0))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec1 = acos_prime * (
+      (n2 * (v2 ^ e1)) / (abs(n1) * abs(n2)) -
+      ((n1 * n2) * (n1 * (v2 ^ e1))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec2 = acos_prime * (
+      (n2 * (v2 ^ e2)) / (abs(n1) * abs(n2)) -
+      ((n1 * n2) * (n1 * (v2 ^ e2))) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)));
+    returnvec.setX(returnvec0);
+    returnvec.setY(returnvec1);
+    returnvec.setZ(returnvec2);
+    return returnvec;
+    break;
+  }
+  case (1): { //
+    returnvec0 =
+        acos_prime *
+        ((n1 * (v3 ^ e0) + n2 * ((e0 ^ v1) + (e0 ^ v2))) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * ((e0 ^ v1) + (e0 ^ v2))) /
+               (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * (v3 ^ e0)) / (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec1 =
+        acos_prime *
+        ((n1 * (v3 ^ e1) + n2 * ((e1 ^ v1) + (e1 ^ v2))) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * ((e1 ^ v1) + (e1 ^ v2))) /
+               (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * (v3 ^ e1)) / (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec2 =
+        acos_prime *
+        ((n1 * (v3 ^ e2) + n2 * ((e2 ^ v1) + (e2 ^ v2))) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * ((e2 ^ v1) + (e2 ^ v2))) /
+               (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * (v3 ^ e2)) / (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec.setX(returnvec0);
+    returnvec.setY(returnvec1);
+    returnvec.setZ(returnvec2);
+    return returnvec;
+    break;
+  };
+  case (2): { //
+    returnvec0 =
+        acos_prime *
+        ((n1 * ((e0 ^ v2) + (e0 ^ v3)) + n2 * (v1 ^ e0)) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * (v1 ^ e0)) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * ((e0 ^ v2) + (e0 ^ v3))) /
+               (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec1 =
+        acos_prime *
+        ((n1 * ((e1 ^ v2) + (e1 ^ v3)) + n2 * (v1 ^ e1)) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * (v1 ^ e1)) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * ((e1 ^ v2) + (e1 ^ v3))) /
+               (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec2 =
+        acos_prime *
+        ((n1 * ((e2 ^ v2) + (e2 ^ v3)) + n2 * (v1 ^ e2)) / (abs(n1) * abs(n2)) -
+         ((n1 * n2) *
+          ((n1 * (v1 ^ e2)) / (abs(n1) * abs(n1) * abs(n1) * abs(n2)) +
+           (n2 * ((e2 ^ v2) + (e2 ^ v3))) /
+               (abs(n1) * abs(n2) * abs(n2) * abs(n2)))));
+    returnvec.setX(returnvec0);
+    returnvec.setY(returnvec1);
+    returnvec.setZ(returnvec2);
+    return returnvec;
+    break;
+  };
+  case (3): { //
+    returnvec0 = acos_prime * ((n1 * (v2 ^ e0)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n2 * (v2 ^ e0))) /
+                                   (abs(n1) * abs(n2) * abs(n2) * abs(n2)));
+    returnvec1 = acos_prime * ((n1 * (v2 ^ e1)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n2 * (v2 ^ e1))) /
+                                   (abs(n1) * abs(n2) * abs(n2) * abs(n2)));
+    returnvec2 = acos_prime * ((n1 * (v2 ^ e2)) / (abs(n1) * abs(n2)) -
+                               ((n1 * n2) * (n2 * (v2 ^ e2))) /
+                                   (abs(n1) * abs(n2) * abs(n2) * abs(n2)));
+    returnvec.setX(returnvec0);
+    returnvec.setY(returnvec1);
+    returnvec.setZ(returnvec2);
+    return returnvec;
+    break;
+  };
+  }
+  // should never reach this
+  assert(false);
+  return vec(0, 0, 0);
+}
+}
+}
 
+#endif // _VOTCA_CSG_INTERACTION_H

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -167,22 +167,6 @@ inline double IAngle::EvaluateVar(const Topology &top)
 
 inline vec IAngle::Grad(const Topology &top, int bead)
 {
-    /*vec v1(top.getDist(_beads[1], _beads[0]));
-    vec v2(top.getDist(_beads[1], _beads[2]));
-    
-    double av1 = abs(v1);
-    double av2 = abs(v2);
-    double cosphi = v1*v2 / (av1*av2);
-    double acos_prime = -1.0 / (sqrt(1 - (cosphi*cosphi) ));
-    
-    switch (bead) {
-        case (0): return acos_prime * (v2 / (av1*av2) - v1*cosphi/(av1*av1)); break;
-        case (1): return -acos_prime * ( (v1+v2)/(av1 * av2)) - 
-                cosphi * ( v1/(av1*av1) + v2/(av2*av2) ); break;
-        case (2): return acos_prime * (v1 / (av1*av2) - v2*cosphi/(av2*av2)); break;
-    }
-    return 0;
-    */
     vec v1(top.getDist(_beads[1], _beads[0]));
     vec v2(top.getDist(_beads[1], _beads[2]));
     
@@ -207,8 +191,6 @@ inline double IDihedral::EvaluateVar(const Topology &top)
     n2 = v2^v3; // calculate the normal vector
     double sign = (v1*n2 < 0) ? -1 : 1;
     return sign*acos(n1*n2/sqrt((n1*n1) * (n2*n2)));
-    //return sign*acos(n1*n2/sqrt((n1*n1) * (n2*n2))) + 1;
-    //return pow(acos(n1*n2/sqrt((n1*n1) * (n2*n2))), 2);
 }
 
 inline vec IDihedral::Grad(const Topology &top, int bead)
@@ -217,8 +199,6 @@ inline vec IDihedral::Grad(const Topology &top, int bead)
     vec v2(top.getDist(_beads[1], _beads[2]));
     vec v3(top.getDist(_beads[2], _beads[3]));
     vec n1, n2;
-    //cout << "v1: " << v1 << " , v2: " << v2 <<  " , v3: " << v3 <<endl;
-    //cout << "n1: " << n1 << " , n2: " << n2 << endl;
     n1 = v1^v2; // calculate the normal vector
     n2 = v2^v3; // calculate the normal vector
     double sign = (v1*n2 < 0) ? -1 : 1;

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2009-2016 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _interaction_H
-#define	_interaction_H
+#ifndef _VOTCA_CSG_INTERACTION_H
+#define	_VOTCA_CSG_INTERACTION_H
 
 #include <string>
 #include <sstream>
@@ -84,14 +84,14 @@ protected:
 inline void Interaction::RebuildName()
 {
     stringstream s;
-    if(_mol!=-1) s << "molecule " << _mol+1;
-    if(_group.compare("")==0) {
+    if(_mol!=-1) s << "molecule " << _mol;
+    if(!_group.empty()) {
       s << ":" << _group;
       if(_group_id!=-1){
         s << " " << _group_id;
       }
     }
-    if(_index!=-1) s << ":bond " << _index+1;
+    if(_index!=-1) s << ":index " << _index;
     _name = s.str();
 }
 
@@ -279,5 +279,5 @@ inline vec IDihedral::Grad(const Topology &top, int bead)
 
 }}
 
-#endif	/* _interaction_H */
+#endif	// _VOTCA_CSG_INTERACTION_H 
 

--- a/include/votca/csg/interaction.h
+++ b/include/votca/csg/interaction.h
@@ -37,10 +37,16 @@ using namespace std;
 class Interaction
 {
 public:
+    Interaction() :
+      _index(-1),
+      _group(""),
+      _group_id(-1),
+      _name(""),
+      _mol(-1) {};
+
     virtual ~Interaction() { }
     virtual double EvaluateVar(const Topology &top) = 0;
         
-    void setName(const string &name) { _name = name; }
     string getName() const { return _name; }
         
     void setGroup(const string &group) { _group = group; RebuildName(); }
@@ -75,7 +81,9 @@ protected:
 inline void Interaction::RebuildName()
 {
     stringstream s;
-    s << _mol+1  << ":" << _group << ":" << _index+1;
+    if(_mol!=-1) s << _mol+1;
+    if(_group.compare("")==0) s << ":" << _group;
+    if(_index!=-1) s << ":" << _index+1;
     _name = s.str();
 }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Boost 1.39.0 REQUIRED COMPONENTS unit_test_framework)
-foreach(PROG test_pdbreader test_bead test_lammpsreaderwriter)
+foreach(PROG test_pdbreader test_bead test_interaction test_lammpsreaderwriter)
   file(GLOB ${PROG}_SOURCES ${PROG}*.cc)
   add_executable(unit_${PROG} ${${PROG}_SOURCES})
   target_link_libraries(unit_${PROG} votca_csg ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/src/tests/test_interaction.cc
+++ b/src/tests/test_interaction.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE interaction_test
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <votca/csg/bead.h>
+#include <votca/csg/interaction.h>
+#include <votca/csg/beadtype.h>
+#include <votca/csg/topology.h>
+#include <votca/csg/molecule.h>
+#include <votca/tools/vec.h>
+
+using namespace std;
+using namespace votca::csg;
+
+BOOST_AUTO_TEST_SUITE(interaction_test)
+
+BOOST_AUTO_TEST_CASE(test_interaction_constructor) {
+  IBond bond1(1,2);
+  IAngle angle1(1,2,3);
+  IDihedral dihedral(1,2,3,4);
+}
+
+BOOST_AUTO_TEST_CASE(test_interaction_setters_getters){
+
+  IBond bond1(1,2);
+  bond1.setGroup("large");
+  bond1.setGroupId(1);
+  bond1.setIndex(1);
+  bond1.setMolecule(1);
+  
+  string name = bond1.getName();
+  cout << name << endl;
+  bool correctName = name.compare("molecule 1:large 1:index 1")==0;
+  BOOST_CHECK(correctName);
+  BOOST_CHECK_EQUAL(bond1.getGroupId(),1);  
+  BOOST_CHECK_EQUAL(bond1.getIndex(),1);  
+  BOOST_CHECK_EQUAL(bond1.getMolecule(),1);  
+  BOOST_CHECK_EQUAL(bond1.BeadCount(),2);  
+  BOOST_CHECK_EQUAL(bond1.getBeadId(0),1);  
+  BOOST_CHECK_EQUAL(bond1.getBeadId(1),2);  
+  string groupName = bond1.getGroup();
+  correctName = groupName.compare("large")==0;
+  
+  BOOST_CHECK(correctName);
+
+  IAngle angle1(1,2,3);
+  angle1.setGroup("medium");
+  angle1.setGroupId(1);
+  angle1.setIndex(1);
+  angle1.setMolecule(1);
+
+  name = angle1.getName();
+  cout << name << endl;
+  correctName = name.compare("molecule 1:medium 1:index 1")==0;
+  BOOST_CHECK(correctName);
+  BOOST_CHECK_EQUAL(angle1.getGroupId(),1);  
+  BOOST_CHECK_EQUAL(angle1.getIndex(),1);  
+  BOOST_CHECK_EQUAL(angle1.getMolecule(),1);  
+  BOOST_CHECK_EQUAL(angle1.BeadCount(),3);  
+  BOOST_CHECK_EQUAL(angle1.getBeadId(0),1);  
+  BOOST_CHECK_EQUAL(angle1.getBeadId(1),2);  
+  BOOST_CHECK_EQUAL(angle1.getBeadId(2),3);  
+  groupName = angle1.getGroup();
+  correctName = groupName.compare("medium")==0;
+ 
+  IDihedral dihedral1(1,2,3,4);
+  dihedral1.setGroup("small");
+  dihedral1.setGroupId(1);
+  dihedral1.setIndex(1);
+  dihedral1.setMolecule(1);
+
+  name = dihedral1.getName();
+  cout << name << endl;
+  correctName = name.compare("molecule 1:small 1:index 1")==0;
+  BOOST_CHECK(correctName);
+  BOOST_CHECK_EQUAL(dihedral1.getGroupId(),1);  
+  BOOST_CHECK_EQUAL(dihedral1.getIndex(),1);  
+  BOOST_CHECK_EQUAL(dihedral1.getMolecule(),1);  
+  BOOST_CHECK_EQUAL(dihedral1.BeadCount(),4);  
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(0),1);  
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(1),2);  
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(2),3);  
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(3),4);  
+  groupName = dihedral1.getGroup();
+  correctName = groupName.compare("small")==0;
+ 
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_interaction.cc
+++ b/src/tests/test_interaction.cc
@@ -22,10 +22,10 @@
 
 #include <string>
 #include <votca/csg/bead.h>
-#include <votca/csg/interaction.h>
 #include <votca/csg/beadtype.h>
-#include <votca/csg/topology.h>
+#include <votca/csg/interaction.h>
 #include <votca/csg/molecule.h>
+#include <votca/csg/topology.h>
 #include <votca/tools/vec.h>
 
 using namespace std;
@@ -34,35 +34,35 @@ using namespace votca::csg;
 BOOST_AUTO_TEST_SUITE(interaction_test)
 
 BOOST_AUTO_TEST_CASE(test_interaction_constructor) {
-  IBond bond1(1,2);
-  IAngle angle1(1,2,3);
-  IDihedral dihedral(1,2,3,4);
+  IBond bond1(1, 2);
+  IAngle angle1(1, 2, 3);
+  IDihedral dihedral(1, 2, 3, 4);
 }
 
-BOOST_AUTO_TEST_CASE(test_interaction_setters_getters){
+BOOST_AUTO_TEST_CASE(test_interaction_setters_getters) {
 
-  IBond bond1(1,2);
+  IBond bond1(1, 2);
   bond1.setGroup("large");
   bond1.setGroupId(1);
   bond1.setIndex(1);
   bond1.setMolecule(1);
-  
+
   string name = bond1.getName();
   cout << name << endl;
-  bool correctName = name.compare("molecule 1:large 1:index 1")==0;
+  bool correctName = name.compare("molecule 1:large 1:index 1") == 0;
   BOOST_CHECK(correctName);
-  BOOST_CHECK_EQUAL(bond1.getGroupId(),1);  
-  BOOST_CHECK_EQUAL(bond1.getIndex(),1);  
-  BOOST_CHECK_EQUAL(bond1.getMolecule(),1);  
-  BOOST_CHECK_EQUAL(bond1.BeadCount(),2);  
-  BOOST_CHECK_EQUAL(bond1.getBeadId(0),1);  
-  BOOST_CHECK_EQUAL(bond1.getBeadId(1),2);  
+  BOOST_CHECK_EQUAL(bond1.getGroupId(), 1);
+  BOOST_CHECK_EQUAL(bond1.getIndex(), 1);
+  BOOST_CHECK_EQUAL(bond1.getMolecule(), 1);
+  BOOST_CHECK_EQUAL(bond1.BeadCount(), 2);
+  BOOST_CHECK_EQUAL(bond1.getBeadId(0), 1);
+  BOOST_CHECK_EQUAL(bond1.getBeadId(1), 2);
   string groupName = bond1.getGroup();
-  correctName = groupName.compare("large")==0;
-  
+  correctName = groupName.compare("large") == 0;
+
   BOOST_CHECK(correctName);
 
-  IAngle angle1(1,2,3);
+  IAngle angle1(1, 2, 3);
   angle1.setGroup("medium");
   angle1.setGroupId(1);
   angle1.setIndex(1);
@@ -70,19 +70,19 @@ BOOST_AUTO_TEST_CASE(test_interaction_setters_getters){
 
   name = angle1.getName();
   cout << name << endl;
-  correctName = name.compare("molecule 1:medium 1:index 1")==0;
+  correctName = name.compare("molecule 1:medium 1:index 1") == 0;
   BOOST_CHECK(correctName);
-  BOOST_CHECK_EQUAL(angle1.getGroupId(),1);  
-  BOOST_CHECK_EQUAL(angle1.getIndex(),1);  
-  BOOST_CHECK_EQUAL(angle1.getMolecule(),1);  
-  BOOST_CHECK_EQUAL(angle1.BeadCount(),3);  
-  BOOST_CHECK_EQUAL(angle1.getBeadId(0),1);  
-  BOOST_CHECK_EQUAL(angle1.getBeadId(1),2);  
-  BOOST_CHECK_EQUAL(angle1.getBeadId(2),3);  
+  BOOST_CHECK_EQUAL(angle1.getGroupId(), 1);
+  BOOST_CHECK_EQUAL(angle1.getIndex(), 1);
+  BOOST_CHECK_EQUAL(angle1.getMolecule(), 1);
+  BOOST_CHECK_EQUAL(angle1.BeadCount(), 3);
+  BOOST_CHECK_EQUAL(angle1.getBeadId(0), 1);
+  BOOST_CHECK_EQUAL(angle1.getBeadId(1), 2);
+  BOOST_CHECK_EQUAL(angle1.getBeadId(2), 3);
   groupName = angle1.getGroup();
-  correctName = groupName.compare("medium")==0;
- 
-  IDihedral dihedral1(1,2,3,4);
+  correctName = groupName.compare("medium") == 0;
+
+  IDihedral dihedral1(1, 2, 3, 4);
   dihedral1.setGroup("small");
   dihedral1.setGroupId(1);
   dihedral1.setIndex(1);
@@ -90,19 +90,18 @@ BOOST_AUTO_TEST_CASE(test_interaction_setters_getters){
 
   name = dihedral1.getName();
   cout << name << endl;
-  correctName = name.compare("molecule 1:small 1:index 1")==0;
+  correctName = name.compare("molecule 1:small 1:index 1") == 0;
   BOOST_CHECK(correctName);
-  BOOST_CHECK_EQUAL(dihedral1.getGroupId(),1);  
-  BOOST_CHECK_EQUAL(dihedral1.getIndex(),1);  
-  BOOST_CHECK_EQUAL(dihedral1.getMolecule(),1);  
-  BOOST_CHECK_EQUAL(dihedral1.BeadCount(),4);  
-  BOOST_CHECK_EQUAL(dihedral1.getBeadId(0),1);  
-  BOOST_CHECK_EQUAL(dihedral1.getBeadId(1),2);  
-  BOOST_CHECK_EQUAL(dihedral1.getBeadId(2),3);  
-  BOOST_CHECK_EQUAL(dihedral1.getBeadId(3),4);  
+  BOOST_CHECK_EQUAL(dihedral1.getGroupId(), 1);
+  BOOST_CHECK_EQUAL(dihedral1.getIndex(), 1);
+  BOOST_CHECK_EQUAL(dihedral1.getMolecule(), 1);
+  BOOST_CHECK_EQUAL(dihedral1.BeadCount(), 4);
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(0), 1);
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(1), 2);
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(2), 3);
+  BOOST_CHECK_EQUAL(dihedral1.getBeadId(3), 4);
   groupName = dihedral1.getGroup();
-  correctName = groupName.compare("small")==0;
- 
+  correctName = groupName.compare("small") == 0;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tools/csg_dlptopol.cc
+++ b/src/tools/csg_dlptopol.cc
@@ -261,8 +261,10 @@ void DLPTopolApp::WriteMoleculeInteractions(ostream &out, Molecule &cg)
                     out << "dihedrals ";
                     break;
                 default:
-                    throw runtime_error(string("cannot handle number of beads in interaction:") +
-                            ic->getName());
+                    string err = "cannot handle number of beads in interaction:";
+                    err += to_string(ic->getMolecule()+1)+":"+ic->getGroup();
+                    err += ":"+to_string(ic->getIndex()+1);
+                    throw runtime_error(err);
             }
         }
 	n_entries++;
@@ -271,8 +273,10 @@ void DLPTopolApp::WriteMoleculeInteractions(ostream &out, Molecule &cg)
         sout << " tab ";
         for(int i=0; i<nb; ++i)
 	  sout << ic->getBeadId(i)+1 << " ";
-        sout << "   1.00000  0.00000" << " # " << ic->getName() << endl;
-        //sout << "   1.00000  0.00000" << " # " << ic->getGroup() << endl;
+        sout << "   1.00000  0.00000" << " # ";
+        sout << to_string(ic->getMolecule()+1) ;
+        sout << ":"+ic->getGroup();
+        sout << ":"+to_string(ic->getIndex()+1) << endl;
     }
     if(sout.str()!="") out << n_entries << endl << sout.str();
 }

--- a/src/tools/csg_gmxtopol.cc
+++ b/src/tools/csg_gmxtopol.cc
@@ -108,13 +108,18 @@ void GmxTopolApp::WriteInteractions(ostream &out, Molecule &cg)
                     out << "\n[ dihedrals ]\n";
                     break;
                 default:
-                    throw runtime_error(string("cannot handle number of beads in interaction:") +
-                            ic->getName());
+                    string err = "cannot handle number of beads in interaction:";
+                    err += to_string(ic->getMolecule()+1)+":"+ic->getGroup();
+                    err += ":"+to_string(ic->getIndex()+1);
+                    throw runtime_error(err);
             }
         }
         for(int i=0; i<nb; ++i)
             out << ic->getBeadId(i)+1 << " ";
-        out << "  1  ; " << ic->getName() << endl;
+        out << "  1  ; ";
+        out << to_string(ic->getMolecule()+1) ;
+        out << ":"+ic->getGroup();
+        out << ":"+to_string(ic->getIndex()+1) << endl;
     }
 }
 


### PR DESCRIPTION
Was finding when running valgrind that garbage values will be used without warning if one does not set some of the values. This was solved by placing asserts where needed to ensure the users do not do this. Also found that there was ambiguity in the class because the the internal name is created by using the group group index molecule id and index of the class. However there was also a method to directly change the name without updating these other values setting up the class instance to become out of date by using the setName method. Thus the setName method was removed as it was not used anywhere in the code base anyway according to a search in netbeans. The change in the way the name is printed should also not have a large impact as it is only printed in the output of two files in the comment classes. 

Fix #264