### PR TITLE
1. Move get and set Q to bead.h file and class instead of basebead.h

### DIFF
--- a/include/votca/csg/basebead.h
+++ b/include/votca/csg/basebead.h
@@ -79,18 +79,6 @@ public:
   virtual void setMass(const double &m) { _mass = m; }
 
   /**
-   * get the charge of the base bead
-   * \return - base bead charge
-   */
-  virtual const double &getQ() const { return _q; }
-
-  /**
-   * set the charge of the base bead
-   * \param - base bead charge
-   */
-  virtual void setQ(const double &q) { _q = q; }
-
-  /**
    * set the position of the base bead
    * \param - base bead position
    */
@@ -128,13 +116,12 @@ public:
 protected:
   BaseBead()
       : TopologyItem(nullptr), _type(nullptr), _mol(nullptr), _mass(0.0),
-        _q(0.0), _bPos(false){};
+        _bPos(false){};
 
   BeadType *_type;
   Molecule *_mol;
 
   double _mass;
-  double _q;
   vec _pos;
 
   bool _bPos;

--- a/include/votca/csg/bead.h
+++ b/include/votca/csg/bead.h
@@ -341,7 +341,7 @@ protected:
   /// constructur
   Bead(Topology *owner, int id, BeadType *type, byte_t symmetry, string name,
        int resnr, double m, double q)
-      : _symmetry(symmetry), _resnr(resnr), _q(q) {
+      : _symmetry(symmetry), _q(q), _resnr(resnr) {
     _parent = owner;
     setId(id);
     setType(type);

--- a/include/votca/csg/bead.h
+++ b/include/votca/csg/bead.h
@@ -79,6 +79,18 @@ public:
   }
 
   /**
+   * get the charge of the bead
+   * \return - base bead charge
+   */
+  virtual const double &getQ() const { return _q; }
+
+  /**
+   * set the charge of the base bead
+   * \param[in] - base bead position
+   */
+  virtual void setQ(const double &q) { _q = q; }
+
+  /**
    * \brief get the symmetry of the bead
    *
    * Returns the number of unique axis of the bead, it can be
@@ -314,6 +326,7 @@ protected:
   Property *_options;
 
   byte_t _symmetry;
+  double _q;
 
   int _resnr;
 
@@ -328,13 +341,12 @@ protected:
   /// constructur
   Bead(Topology *owner, int id, BeadType *type, byte_t symmetry, string name,
        int resnr, double m, double q)
-      : _symmetry(symmetry), _resnr(resnr) {
+      : _symmetry(symmetry), _resnr(resnr), _q(q) {
     _parent = owner;
     setId(id);
     setType(type);
     setName(name);
     setMass(m);
-    setQ(q);
     _bPos = false;
     _bVel = false;
     _bU = false;

--- a/src/libcsg/beadstructure.cc
+++ b/src/libcsg/beadstructure.cc
@@ -35,7 +35,6 @@ shared_ptr<GraphNode> BaseBeadToGraphNode(BaseBead *basebead) {
   unordered_map<string, string> attributes2;
 
   attributes1["Mass"] = basebead->getMass();
-  attributes1["Charge"] = basebead->getQ();
   attributes2["Name"] = basebead->getName();
 
   /// Add graphnodes

--- a/src/tests/test_basebead.cc
+++ b/src/tests/test_basebead.cc
@@ -52,7 +52,6 @@ BOOST_AUTO_TEST_CASE(test_basebead_getters_setters) {
 
   TestBead basebead;
   BOOST_CHECK_EQUAL(round_(basebead.getMass(), 3), round_(0.0, 3));
-  BOOST_CHECK_EQUAL(round_(basebead.getQ(), 3), round_(0.0, 3));
   BOOST_CHECK(!basebead.HasPos());
 
   basebead.setId(0);
@@ -64,9 +63,6 @@ BOOST_AUTO_TEST_CASE(test_basebead_getters_setters) {
 
   basebead.setMass(1.0);
   BOOST_CHECK_EQUAL(round_(basebead.getMass(), 3), round_(1.0, 3));
-
-  basebead.setQ(2.0);
-  BOOST_CHECK_EQUAL(round_(basebead.getQ(), 3), round_(2.0, 3));
 
   vec xyz(-1.3, 2.9, 9.2);
   basebead.setPos(xyz);


### PR DESCRIPTION
2. also updated unit test to reflect this

The purpose of doing this it to better align the base bead class with what is in the xtp atom class. The xtp class has a much more involved charge description thus it makes sense to move the functionality out of the base bead class. 