### PR TITLE
Create moleculeitem class

### DIFF
--- a/include/votca/csg/basebead.h
+++ b/include/votca/csg/basebead.h
@@ -19,6 +19,7 @@
 #define _VOTCA_CSG_BASEBEAD_H
 
 #include <votca/csg/topologyitem.h>
+#include <votca/csg/moleculeitem.h>
 
 #include <votca/tools/identity.h>
 #include <votca/tools/name.h>
@@ -28,7 +29,6 @@ namespace votca {
 namespace csg {
 using namespace votca::tools;
 
-class Molecule;
 class BeadType;
 
 /**
@@ -40,6 +40,7 @@ class BeadType;
  *
  **/
 class BaseBead : public TopologyItem,
+                 public MoleculeItem,
                  public virtual Name,
                  public virtual Identity<int> {
 public:
@@ -117,21 +118,12 @@ public:
   /** set has position to true */
   void HasPos(bool true_or_false) { _bPos = true_or_false; }
 
-  /**
-   * molecule the base bead belongs to
-   * \return Molecule object
-   */
-  virtual Molecule *getMolecule() { return _mol; }
-
-  virtual void setMolecule(Molecule *mol);
-
 protected:
   BaseBead()
-      : TopologyItem(nullptr), _type(nullptr), _mol(nullptr), _mass(0.0),
-        _q(0.0), _bPos(false){};
+      : TopologyItem(nullptr), MoleculeItem(nullptr), _type(nullptr), 
+      _mass(0.0), _q(0.0), _bPos(false){};
 
   BeadType *_type;
-  Molecule *_mol;
 
   double _mass;
   double _q;
@@ -139,8 +131,6 @@ protected:
 
   bool _bPos;
 };
-
-inline void BaseBead::setMolecule(Molecule *mol) { _mol = mol; }
 
 inline void BaseBead::setPos(const vec &r) {
   _bPos = true;

--- a/include/votca/csg/moleculeitem.h
+++ b/include/votca/csg/moleculeitem.h
@@ -1,0 +1,43 @@
+/* 
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef _VOTCA_CSG_MOLECULEITEM_H
+#define	_VOTCA_CSG_MOLECULEITEM_H
+
+namespace votca { namespace csg {
+
+class Molecule;
+
+class MoleculeItem
+{
+public:    
+    virtual ~MoleculeItem() {}
+    Molecule *getMolecule() { return _mol; }
+    void setMolecule(Molecule *mol) { _mol = mol; }
+
+protected:
+    MoleculeItem(Molecule *mol)
+        : _mol(mol) {}
+    
+    Molecule *_mol;
+    
+};
+
+}}
+
+#endif	// _VOTCA_CSG_MOLECULEITEM_H
+

--- a/include/votca/csg/moleculeitem.h
+++ b/include/votca/csg/moleculeitem.h
@@ -33,7 +33,7 @@ public:
    * Returns the molecule the pointer points at
    */
   Molecule *getMolecule() {
-    assert(mol != nullptr);
+    assert(_mol != nullptr);
     return _mol;
   }
 

--- a/include/votca/csg/moleculeitem.h
+++ b/include/votca/csg/moleculeitem.h
@@ -18,6 +18,8 @@
 #ifndef _VOTCA_CSG_MOLECULEITEM_H
 #define	_VOTCA_CSG_MOLECULEITEM_H
 
+#include <cassert>
+
 namespace votca { namespace csg {
 
 class Molecule;
@@ -26,14 +28,22 @@ class MoleculeItem
 {
 public:    
     virtual ~MoleculeItem() {}
-    Molecule *getMolecule() { return _mol; }
+
+    /**
+     * Returns the molecule the pointer points at
+     */
+    Molecule *getMolecule() { assert(mol!=nullptr); return _mol; }
+
+    /**
+     * stores a pointer to a molecule
+     */
     void setMolecule(Molecule *mol) { _mol = mol; }
 
 protected:
     MoleculeItem(Molecule *mol)
         : _mol(mol) {}
     
-    Molecule *_mol;
+    Molecule *_mol = nullptr;
     
 };
 

--- a/include/votca/csg/moleculeitem.h
+++ b/include/votca/csg/moleculeitem.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,38 +16,38 @@
  */
 
 #ifndef _VOTCA_CSG_MOLECULEITEM_H
-#define	_VOTCA_CSG_MOLECULEITEM_H
+#define _VOTCA_CSG_MOLECULEITEM_H
 
 #include <cassert>
 
-namespace votca { namespace csg {
+namespace votca {
+namespace csg {
 
 class Molecule;
 
-class MoleculeItem
-{
-public:    
-    virtual ~MoleculeItem() {}
+class MoleculeItem {
+public:
+  virtual ~MoleculeItem() {}
 
-    /**
-     * Returns the molecule the pointer points at
-     */
-    Molecule *getMolecule() { assert(mol!=nullptr); return _mol; }
+  /**
+   * Returns the molecule the pointer points at
+   */
+  Molecule *getMolecule() {
+    assert(mol != nullptr);
+    return _mol;
+  }
 
-    /**
-     * stores a pointer to a molecule
-     */
-    void setMolecule(Molecule *mol) { _mol = mol; }
+  /**
+   * stores a pointer to a molecule
+   */
+  void setMolecule(Molecule *mol) { _mol = mol; }
 
 protected:
-    MoleculeItem(Molecule *mol)
-        : _mol(mol) {}
-    
-    Molecule *_mol = nullptr;
-    
+  MoleculeItem(Molecule *mol) : _mol(mol) {}
+
+  Molecule *_mol = nullptr;
 };
+}
+}
 
-}}
-
-#endif	// _VOTCA_CSG_MOLECULEITEM_H
-
+#endif // _VOTCA_CSG_MOLECULEITEM_H


### PR DESCRIPTION
This add flexibility to the base bead class, if we need to move the get and set molecule methods to more concrete uses than we can now easily do this, this may very well be the case, furthermore it follows the same design structure as the topologyitem class and thus adds consistency. 