### PR TITLE
Thread class update

### DIFF
--- a/include/votca/csg/csgapplication.h
+++ b/include/votca/csg/csgapplication.h
@@ -129,7 +129,7 @@ namespace votca {
                 TopologyMap * _map;
                 int _id;
 
-                void Run(void);
+                void _Run(void);
 
                 void setApplication(CsgApplication *app) {
                     _app = app;

--- a/include/votca/csg/csgapplication.h
+++ b/include/votca/csg/csgapplication.h
@@ -129,7 +129,7 @@ namespace votca {
                 TopologyMap * _map;
                 int _id;
 
-                void _Run(void);
+                void Run(void);
 
                 void setApplication(CsgApplication *app) {
                     _app = app;

--- a/include/votca/csg/topology.h
+++ b/include/votca/csg/topology.h
@@ -62,10 +62,8 @@ class Topology
 {
 public:
     /// constructor
-    Topology() {
+    Topology() : _time(0.0), _has_vel(false), _has_force(false) {
         _bc = new OpenBox();
-        _has_vel=false;
-        _has_force=false;
     }
     virtual ~Topology();
     

--- a/src/libcsg/csgapplication.cc
+++ b/src/libcsg/csgapplication.cc
@@ -125,7 +125,7 @@ namespace votca {
             //out << "\n\n" << OptionsDesc() << endl;
         }
 
-        void CsgApplication::Worker::Run(void) {
+        void CsgApplication::Worker::_Run(void) {
             while (_app->ProcessData(this)) {
                 if (_app->SynchronizeThreads()) {
                     int id = getId();
@@ -368,7 +368,8 @@ namespace votca {
 
 
                 } else {
-                    master->Run();
+                    master->Start();
+                    master->WaitDone();
                     delete master;
                 }
 

--- a/src/libcsg/csgapplication.cc
+++ b/src/libcsg/csgapplication.cc
@@ -125,7 +125,7 @@ namespace votca {
             //out << "\n\n" << OptionsDesc() << endl;
         }
 
-        void CsgApplication::Worker::_Run(void) {
+        void CsgApplication::Worker::Run(void) {
             while (_app->ProcessData(this)) {
                 if (_app->SynchronizeThreads()) {
                     int id = getId();

--- a/src/libcsg/map.cc
+++ b/src/libcsg/map.cc
@@ -140,7 +140,7 @@ void Map_Sphere::Apply()
     for(iter = _matrix.begin(); iter != _matrix.end(); ++iter) {
         Bead *bead = iter->_in;
         _out->ParentBeads().push_back(bead->getId());
-        M+=bead->getM();
+        M+=bead->getMass();
         if(bead->HasPos()) {
             vec r = top->BCShortestConnection(r0, bead->getPos());
             if(abs(r) > max_dist) {
@@ -161,7 +161,7 @@ void Map_Sphere::Apply()
             bF = true;
         }
     }
-    _out->setM(M);
+    _out->setMass(M);
     if(bPos)
         _out->setPos(cg);
     if(bVel)

--- a/src/libcsg/modules/io/dlpolytopologyreader.cc
+++ b/src/libcsg/modules/io/dlpolytopologyreader.cc
@@ -292,7 +292,7 @@ bool DLPOLYTopologyReader::ReadTopology(string file, Topology &top)
 	    Bead *bead=mi->getBead(i);
 	    BeadType *type = top.GetOrCreateBeadType(bead->Type()->getName());
 	    string beadname=mi->getBeadName(i);
-	    Bead *bead_replica = top.CreateBead(1, bead->getName(), type, res->getId(), bead->getM(), bead->getQ());
+	    Bead *bead_replica = top.CreateBead(1, bead->getName(), type, res->getId(), bead->getMass(), bead->getQ());
 	    mi_replica->AddBead(bead_replica,beadname);
 	  }
 	  matoms+=mi->BeadCount();

--- a/src/libcsg/modules/io/dlpolytrajectorywriter.cc
+++ b/src/libcsg/modules/io/dlpolytrajectorywriter.cc
@@ -122,7 +122,7 @@ void DLPOLYTrajectoryWriter::Write(Topology *conf)
       } else {
 
 	_fl << setw(8) << left << bead->getType()->getName() << right << setw(10) << i+1;
-	_fl << setprecision(6) << setw(12) << bead->getM() << setw(12) << bead->getQ() << setw(12) << "   0.0" << endl;
+	_fl << setprecision(6) << setw(12) << bead->getMass() << setw(12) << bead->getQ() << setw(12) << "   0.0" << endl;
 
       }
 

--- a/src/libcsg/topology.cc
+++ b/src/libcsg/topology.cc
@@ -137,7 +137,7 @@ void Topology::Add(Topology *top)
     for(bead=top->_beads.begin(); bead!=top->_beads.end(); ++bead) {
         Bead *bi = *bead;
         BeadType *type =  GetOrCreateBeadType(bi->getType()->getName());
-        CreateBead(bi->getSymmetry(), bi->getName(), type, bi->getResnr()+res0, bi->getM(), bi->getQ());
+        CreateBead(bi->getSymmetry(), bi->getName(), type, bi->getResnr()+res0, bi->getMass(), bi->getQ());
     }
     
     for(res=top->_residues.begin();res!=top->_residues.end(); ++res) {
@@ -175,7 +175,7 @@ void Topology::CopyTopologyData(Topology *top)
     for(it_bead=top->_beads.begin(); it_bead!=top->_beads.end(); ++it_bead) {
         Bead *bi = *it_bead;
         BeadType *type =  GetOrCreateBeadType(bi->getType()->getName());
-        Bead *bn = CreateBead(bi->getSymmetry(), bi->getName(), type, bi->getResnr(), bi->getM(), bi->getQ());
+        Bead *bn = CreateBead(bi->getSymmetry(), bi->getName(), type, bi->getResnr(), bi->getMass(), bi->getQ());
         bn->setOptions(bi->Options());
     }
 
@@ -224,7 +224,7 @@ void Topology::SetBeadTypeMass(string name, double value)
     BeadContainer::iterator bead;
     for(bead=_beads.begin(); bead!=_beads.end(); ++bead) {
       if (wildcmp(name.c_str(),(*bead)->getType()->getName().c_str())) {
-	(*bead)->setM(value);
+	(*bead)->setMass(value);
       }
     }
 


### PR DESCRIPTION
Memory problem was found to originate from from miss using the Thread class is the csgapplication class. This was addressed in tools by making the Run method private, and in csgapplication it was fixed by using the Start and Wait methods in place of the run method. A few other things were updated in the process as well, but they are aesthetic mostly. 