### PR TITLE
Add tests and update csg boltzmann

### DIFF
--- a/src/csg_boltzmann/CMakeLists.txt
+++ b/src/csg_boltzmann/CMakeLists.txt
@@ -1,5 +1,4 @@
 file(GLOB CSG_BO_SOURCES *.cc)
-add_library(votca_csg_boltzmann ${CSG_BO_SOURCES})
 add_executable(csg_boltzmann ${CSG_BO_SOURCES})
 target_link_libraries(csg_boltzmann votca_csg)
 install(TARGETS csg_boltzmann RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
@@ -14,3 +13,6 @@ if (TXT2TAGS_FOUND AND BASH)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/csg_boltzmann.man DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 RENAME csg_boltzmann.1)
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES csg_boltzmann.help csg_boltzmann.t2t)
 endif(TXT2TAGS_FOUND AND BASH)
+
+list(REMOVE_ITEM CSG_BO_SOURCES "main.cc")
+add_library(votca_csg_boltzmann ${CSG_BO_SOURCES})

--- a/src/csg_boltzmann/CMakeLists.txt
+++ b/src/csg_boltzmann/CMakeLists.txt
@@ -1,4 +1,5 @@
 file(GLOB CSG_BO_SOURCES *.cc)
+add_library(votca_csg_boltzmann ${CSG_BO_SOURCES})
 add_executable(csg_boltzmann ${CSG_BO_SOURCES})
 target_link_libraries(csg_boltzmann votca_csg)
 install(TARGETS csg_boltzmann RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/csg_boltzmann/analysistool.h
+++ b/src/csg_boltzmann/analysistool.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,13 @@
  *
  */
 
-#ifndef _analasystool_H
-#define	_analasystool_H
+#ifndef VOTCA_CSG_ANALYSISTOOL_H
+#define	VOTCA_CSG_ANALYSISTOOL_H
 
 #include <map>
 #include <string>
 #include <votca/csg/cgengine.h>
 #include "bondedstatistics.h"
-
-using namespace std;
 
 /**
     \brief base class for all analasys tools
@@ -31,19 +29,22 @@ using namespace std;
     This is the base class for all analasys tool. 
     \todo do option functions!!!
 */
+namespace votca {
+  namespace csg {
+
 class AnalysisTool
 {
 public:
     AnalysisTool() {}
     virtual ~AnalysisTool() {}
     
-    virtual void Register(map<string, AnalysisTool *> &lib) {}
-    virtual void Command(BondedStatistics &bs, string cmd, vector<string> &args) {};
-    virtual void Help(string cmd, vector<string> &args) {};
+    virtual void Register(std::map<std::string, AnalysisTool *> &lib) {}
+    virtual void Command(BondedStatistics &bs, std::string cmd, std::vector<std::string> &args) {};
+    virtual void Help(std::string cmd, std::vector<std::string> &args) {};
     
-private:
-//    map<string, string> _options;
 };
 
-#endif	/* _analasystool_H */
+}
+}
+#endif	// VOTCA_CSG_ANALYSISTOOL_H
 

--- a/src/csg_boltzmann/bondedstatistics.cc
+++ b/src/csg_boltzmann/bondedstatistics.cc
@@ -17,6 +17,9 @@
 
 #include "bondedstatistics.h"
 
+using namespace votca::csg;
+using namespace votca::tools;
+
 void BondedStatistics::BeginCG(Topology *top, Topology *top_atom)
 {
     InteractionContainer &ic = top->BondedInteractions();

--- a/src/csg_boltzmann/bondedstatistics.cc
+++ b/src/csg_boltzmann/bondedstatistics.cc
@@ -17,8 +17,10 @@
 
 #include "bondedstatistics.h"
 
-using namespace votca::csg;
 using namespace votca::tools;
+
+namespace votca {
+  namespace csg {
 
 void BondedStatistics::BeginCG(Topology *top, Topology *top_atom)
 {
@@ -44,4 +46,7 @@ void BondedStatistics::EvalConfiguration(Topology *conf, Topology *conv_atom)
     for(ia=ic.begin(), is = _bonded_values.begin(); ia != ic.end(); ++ia, ++is) {
         (*is)->push_back((*ia)->EvaluateVar(*conf));
     }
+}
+
+}
 }

--- a/src/csg_boltzmann/bondedstatistics.cc
+++ b/src/csg_boltzmann/bondedstatistics.cc
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/csg_boltzmann/bondedstatistics.cc
+++ b/src/csg_boltzmann/bondedstatistics.cc
@@ -38,9 +38,7 @@ void BondedStatistics::EvalConfiguration(Topology *conf, Topology *conv_atom)
     InteractionContainer::iterator ia;
     
     DataCollection<double>::container::iterator is;
-    
     for(ia=ic.begin(), is = _bonded_values.begin(); ia != ic.end(); ++ia, ++is) {
-//        const string &name = (*ia)->getName();        
         (*is)->push_back((*ia)->EvaluateVar(*conf));
     }
 }

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -24,6 +24,15 @@
 using namespace votca::tools;
 using namespace votca::csg;
 
+/**
+ * \brief Class calculates data associated with bond interactions
+ *
+ * This class will essentially calculate and store information related to each
+ * type of interaction. For instance for the IBond which is the interaction
+ * between two beads it will calculate and store the distance between the two
+ * beads involved in the interaction. It will calculate a similar metric for all
+ * other interactions such as IAngle, IDihedral etc...
+ **/
 class BondedStatistics
     : public CGObserver
 {

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -21,6 +21,8 @@
 #include <votca/csg/cgobserver.h>
 #include <votca/tools/datacollection.h>
 
+namespace CSG = votca::csg;
+namespace TOOLS = votca::tools;
 /**
  * \brief Class calculates data associated with bond interactions
  *
@@ -31,18 +33,18 @@
  * other interactions such as IAngle, IDihedral etc...
  **/
 class BondedStatistics
-    : public CGObserver
+    : public votca::csg::CGObserver
 {
 public:
-    void BeginCG(Topology *top, Topology *top_atom = 0);
+    void BeginCG(CSG::Topology *top, CSG::Topology *top_atom = 0);
     void EndCG();
     
-    void EvalConfiguration(Topology *conf, Topology *conf_atom = 0);
+    void EvalConfiguration(CSG::Topology *conf, CSG::Topology *conf_atom = 0);
     
-    DataCollection<double> &BondedValues() { return _bonded_values; }
+    TOOLS::DataCollection<double> &BondedValues() { return _bonded_values; }
 
 protected:
-    DataCollection<double> _bonded_values;
+    TOOLS::DataCollection<double> _bonded_values;
 };
 
 #endif	// VOTCA_CSG_BOLZMANNINVERSION_H 

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -21,8 +21,10 @@
 #include <votca/csg/cgobserver.h>
 #include <votca/tools/datacollection.h>
 
-namespace CSG = votca::csg;
 namespace TOOLS = votca::tools;
+
+namespace votca {
+  namespace csg {
 /**
  * \brief Class calculates data associated with bond interactions
  *
@@ -36,16 +38,16 @@ class BondedStatistics
     : public votca::csg::CGObserver
 {
 public:
-    void BeginCG(CSG::Topology *top, CSG::Topology *top_atom = 0);
+    void BeginCG(Topology *top, Topology *top_atom = 0);
     void EndCG();
     
-    void EvalConfiguration(CSG::Topology *conf, CSG::Topology *conf_atom = 0);
+    void EvalConfiguration(Topology *conf, Topology *conf_atom = 0);
     
     TOOLS::DataCollection<double> &BondedValues() { return _bonded_values; }
 
 protected:
     TOOLS::DataCollection<double> _bonded_values;
 };
-
+}}
 #endif	// VOTCA_CSG_BOLZMANNINVERSION_H 
 

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -21,9 +21,6 @@
 #include <votca/csg/cgobserver.h>
 #include <votca/tools/datacollection.h>
 
-using namespace votca::tools;
-using namespace votca::csg;
-
 /**
  * \brief Class calculates data associated with bond interactions
  *

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _BONDEDSTATISTICS_H
-#define	_BONDEDSTATISTICS_H
+#ifndef VOTCA_CSG_BONDEDSTATISTICS_H
+#define	VOTCA_CSG_BONDEDSTATISTICS_H
 
 #include <votca/csg/cgobserver.h>
 #include <votca/tools/datacollection.h>
@@ -48,5 +48,5 @@ protected:
     DataCollection<double> _bonded_values;
 };
 
-#endif	/* _BOLZMANNINVERSION_H */
+#endif	// VOTCA_CSG_BOLZMANNINVERSION_H 
 

--- a/src/csg_boltzmann/main.cc
+++ b/src/csg_boltzmann/main.cc
@@ -33,6 +33,7 @@
 #include <votca/csg/csgapplication.h>
 
 using namespace std;
+using namespace votca::csg;
 
 class CsgBoltzmann
     : public CsgApplication

--- a/src/csg_boltzmann/stdanalysis.cc
+++ b/src/csg_boltzmann/stdanalysis.cc
@@ -24,6 +24,8 @@
 #include "bondedstatistics.h"
 #include "stdanalysis.h"
 
+namespace votca {
+  namespace csg {
 
 void StdAnalysis::Register(map<string, AnalysisTool *> &lib)
 {
@@ -123,3 +125,5 @@ void StdAnalysis::WriteCorrelations(BondedStatistics &bs, vector<string> &args)
     cout << "calculated correlations for " << sel->size() << " rows, written to " << args[0] << endl;
     delete sel;
 }
+
+}}

--- a/src/csg_boltzmann/stdanalysis.h
+++ b/src/csg_boltzmann/stdanalysis.h
@@ -1,5 +1,5 @@
 /* 
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  *
  */
 
-#ifndef _STDANALYSIS_H
-#define	_STDANALYSIS_H
+#ifndef VOTCA_CSG_STDANALYSIS_H
+#define	VOTCA_CSG_STDANALYSIS_H
 
 #include "bondedstatistics.h"
 #include <map>
 
-using namespace std;
-using namespace votca::tools;
-using namespace votca::csg;
+namespace TOOLS = votca::tools;
+
+namespace votca {
+  namespace csg {
 
 class StdAnalysis
     : public AnalysisTool
@@ -32,17 +33,16 @@ class StdAnalysis
         StdAnalysis() {};
         ~StdAnalysis() {};
 
-        void Register(map<string, AnalysisTool *> &lib);
+        void Register(std::map<std::string, AnalysisTool *> &lib);
 
-        void Command(BondedStatistics &bs, string cmd, vector<string> &args);
-        void Help(string cmd, vector<string> &args);
+        void Command(BondedStatistics &bs, std::string cmd, std::vector<std::string> &args);
+        void Help(std::string cmd, std::vector<std::string> &args);
 
-        void WriteValues(BondedStatistics &bs, vector<string> &args);
-        void WriteCorrelations(BondedStatistics &bs, vector<string> &args);
-        void WriteAutocorrelation(BondedStatistics &bs, vector<string> &args);
-    private:
+        void WriteValues(BondedStatistics &bs, std::vector<std::string> &args);
+        void WriteCorrelations(BondedStatistics &bs, std::vector<std::string> &args);
+        void WriteAutocorrelation(BondedStatistics &bs, std::vector<std::string> &args);
 };
 
-
-#endif	/* _STDANALYSIS_H */
+}}
+#endif	// VOTCA_CSG_STDANALYSIS_H 
 

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +15,17 @@
  *
  */
 
-#include <iostream>
+#include "tabulatedpotential.h"
+#include "analysistool.h"
+#include "bondedstatistics.h"
+#include <boost/lexical_cast.hpp>
 #include <fstream>
-#include <vector>
+#include <iostream>
 #include <math.h>
 #include <string>
-#include <boost/lexical_cast.hpp>
-#include "analysistool.h"
-#include <votca/tools/histogram.h>
+#include <vector>
 #include <votca/csg/version.h>
-#include "bondedstatistics.h"
-#include "tabulatedpotential.h"
+#include <votca/tools/histogram.h>
 
 using namespace std;
 using namespace boost;
@@ -36,240 +36,248 @@ const double kB = 0.0083109;
 /******************************************************************************
  * Public Facing Methods
  ******************************************************************************/
-TabulatedPotential::TabulatedPotential()
-{
-    _tab_smooth1 = _tab_smooth2 = 0;
-    _Temperature = 300;
+TabulatedPotential::TabulatedPotential() {
+  _tab_smooth1 = _tab_smooth2 = 0;
+  _Temperature = 300;
 }
 
-void TabulatedPotential::Register(map<string, AnalysisTool *> &lib)
-{
-    lib["tab"] = this;
-    lib["hist"] = this;
+void TabulatedPotential::Register(map<string, AnalysisTool *> &lib) {
+  lib["tab"] = this;
+  lib["hist"] = this;
 }
 
-void TabulatedPotential::Command(BondedStatistics &bs, string cmd, vector<string> &args)
-{
-  if(args[0]=="set") {
-    if(cmd=="hist") {
+void TabulatedPotential::Command(BondedStatistics &bs, string cmd,
+                                 vector<string> &args) {
+  if (args[0] == "set") {
+    if (cmd == "hist") {
       SetOption_(_hist_options, args);
-    }else if(cmd=="tab") {
-      if(!SetOption_(_tab_options, args)) {
-        if(args.size() >2) {
-          if(args[1]=="smooth_pdf"){
-            _tab_smooth1 = lexical_cast<int>(args[2]);       
-          }else if(args[1]=="smooth_pot"){
-            _tab_smooth2 = lexical_cast<int>(args[2]);       
-          } else if(args[1]=="T"){
+    } else if (cmd == "tab") {
+      if (!SetOption_(_tab_options, args)) {
+        if (args.size() > 2) {
+          if (args[1] == "smooth_pdf") {
+            _tab_smooth1 = lexical_cast<int>(args[2]);
+          } else if (args[1] == "smooth_pot") {
+            _tab_smooth2 = lexical_cast<int>(args[2]);
+          } else if (args[1] == "T") {
             _Temperature = lexical_cast<double>(args[2]);
-          }else {
+          } else {
             cout << "unknown option " << args[2] << endl;
             return;
           }
         }
-      }        
-      if(args.size() <=2) {
+      }
+      if (args.size() <= 2) {
         cout << "smooth_pdf: " << _tab_smooth1 << endl;
         cout << "smooth_pot: " << _tab_smooth2 << endl;
         cout << "T: " << _Temperature << endl;
       }
     }
-  }else if(args.size() >= 2) {
-    if(cmd=="hist"){ 
+  } else if (args.size() >= 2) {
+    if (cmd == "hist") {
       WriteHistogram(bs, args);
-    }else if(cmd=="tab"){ 
+    } else if (cmd == "tab") {
       WritePotential(bs, args);
     }
-  }else{ 
+  } else {
     cout << "wrong number of arguments" << endl;
   }
 }
 
+void TabulatedPotential::Help(string cmd, vector<string> &args) {
+  if (args.size() == 0) {
+    if (cmd == "tab") {
+      cout << "tab <file> <selection>\n"
+           << "Calculate tabulated potential by inverting the distribution "
+              "function. Statistics is calculated using all interactions in "
+              "selection.\nsee also: help tab set\n\nexample:\ntab set scale "
+              "bond\ntab U_bond.txt *:bond:*\n";
+    }
+    if (cmd == "hist") {
+      cout << "hist <file> <selection>\n"
+           << "Calculate distribution function for selection. Statistics is "
+              "calculated using all interactions in selection.\n see also: help"
+              " hist set\n\nexample:hist U_bond.txt *:bond:*\n";
+    }
+    return;
+  }
+  if (args[0] == "set") {
+    if (args.size() == 1) {
+      cout << cmd << " set <option> <value>\n"
+           << "set option for this command. Use \"" << cmd
+           << " set\" for a list of available options. To get help on a "
+              "specific option use e.g.\n"
+           << cmd << " set periodic\n";
+      return;
+    }
+    if (args[1] == "n") {
+      cout << cmd << "set n <integer>\n"
+           << "set number of bins for table\n";
+      return;
+    }
+    if (args[1] == "min") {
+      cout << cmd << "set min <value>\n"
+           << "minimum value of interval for histogram (see also periodic, "
+              "extend)\n";
+      return;
+    }
+    if (args[1] == "max") {
+      cout << cmd << "set max <value>\n"
+           << "maximum value of interval for histogram (see also periodic, "
+              "extend)\n";
+      return;
+    }
+    if (args[1] == "periodic") {
+      cout << cmd << "set periodic <value>\n"
+           << "can be 1 for periodic interval (e.g. dihedral) or 0 for "
+              "non-periodic (e.g. bond)\n";
+      return;
+    }
+    if (args[1] == "auto") {
+      cout << cmd
+           << "set auto <value>\n"
+              "can be 1 for automatically determine the interval for the table "
+              "(min, max, extend will be ignored) or 0 to use min/max as "
+              "specified\n";
+      return;
+    }
+    if (args[1] == "extend") {
+      cout << cmd << "set extend <value>\n"
+                     "should only be used with auto=0. Can be 1 for extend the "
+                     "interval if values are out of bounds (min/max) or 0 to "
+                     "ignore values which are out of the interal\n";
+      return;
+    }
+    if (args[1] == "scale") {
+      cout << cmd
+           << "set scale <value>\n"
+              "volume normalization of pdf. Can be no (no scaling), bond "
+              "(1/r^2) or angle ( 1/sin(phi) ). See VOTCA manual, section "
+              "theoretical background for details\n";
+      return;
+    }
+    if (args[1] == "normalize") {
+      cout
+          << cmd
+          << "set normalize <value>\n"
+             "can be 1 for a normalized histogram or 0 to skip normalization\n";
+      return;
+    }
 
-void TabulatedPotential::Help(string cmd, vector<string> &args)
-{
-    if(args.size() == 0) {
-        if(cmd == "tab") {
-            cout << "tab <file> <selection>\n"
-                 << "Calculate tabulated potential by inverting the distribution function. "
-                    "Statistics is calculated using all interactions in selection.\n"
-                    "see also: help tab set\n\n"
-                    "example:\ntab set scale bond\ntab U_bond.txt *:bond:*\n";
-        }
-        if(cmd == "hist") {
-            cout << "hist <file> <selection>\n"
-                 << "Calculate distribution function for selection. "
-                    "Statistics is calculated using all interactions in selection.\n"
-                    "see also: help hist set\n\n"
-                    "example:hist U_bond.txt *:bond:*\n";
-        }
+    if (cmd == "tab") {
+      if (args[1] == "smooth_pdf") {
+        cout << "tab set smooth_pdf <value>\n"
+                "Perform so many smoothing iterations on the distribution "
+                "function before inverting the potential\n";
         return;
+      }
+      if (args[1] == "smooth_pot") {
+        cout << "tab set smooth_pot <value>\n"
+                "Perform so many smoothing iterations on tabulated potential "
+                "after inverting the potential\n";
+        return;
+      }
+      if (args[1] == "T") {
+        cout << "tab set T <value>\n"
+                "Temperature in Kelvin the simulation was performed\n";
+        return;
+      }
     }
-    if(args[0] == "set") {
-        if(args.size() == 1) {
-            cout << cmd << " set <option> <value>\n"
-                 << "set option for this command. Use \"" << cmd << " set\""
-                    " for a list of available options. To get help on a specific option use e.g.\n"
-                    << cmd << " set periodic\n";
-            return;
-        }
-        if(args[1] == "n") {
-            cout << cmd << "set n <integer>\n"
-                 << "set number of bins for table\n";
-            return;
-        }
-        if(args[1] == "min") {
-            cout << cmd << "set min <value>\n"
-                 << "minimum value of interval for histogram (see also periodic, extend)\n";
-            return;
-        }
-        if(args[1] == "max") {
-            cout << cmd << "set max <value>\n"
-                 << "maximum value of interval for histogram (see also periodic, extend)\n";
-            return;
-        }
-        if(args[1] == "periodic") {
-            cout << cmd << "set periodic <value>\n"
-                << "can be 1 for periodic interval (e.g. dihedral) or 0 for "
-                    "non-periodic (e.g. bond)\n";
-            return;
-        }
-        if(args[1] == "auto") {
-            cout << cmd << "set auto <value>\n"
-                 "can be 1 for automatically determine the interval for the "
-                 "table (min, max, extend will be ignored) or 0 to use min/max as specified\n";
-            return;
-        }
-        if(args[1] == "extend") {
-            cout << cmd << "set extend <value>\n"
-                 "should only be used with auto=0. Can be 1 for extend the interval "
-                 "if values are out of bounds (min/max) "
-                 "or 0 to ignore values which are out of the interal\n";
-            return;
-        }
-        if(args[1] == "scale") {
-            cout << cmd << "set scale <value>\n"
-                "volume normalization of pdf. Can be no (no scaling), bond "
-                "(1/r^2) or angle ( 1/sin(phi) ). See VOTCA manual, section "
-                "theoretical background for details\n";
-            return;
-        }
-        if(args[1] == "normalize") {
-            cout << cmd << "set normalize <value>\n"
-                 "can be 1 for a normalized histogram or 0 to skip normalization\n";
-            return;
-        }
+  }
 
-        if(cmd == "tab") {
-            if(args[1] == "smooth_pdf") {
-                cout << "tab set smooth_pdf <value>\n"
-                 "Perform so many smoothing iterations on the distribution function before inverting the potential\n";
-                return;
-            }
-            if(args[1] == "smooth_pot") {
-                cout << "tab set smooth_pot <value>\n"
-                 "Perform so many smoothing iterations on tabulated potential after inverting the potential\n";
-                return;
-            }
-            if(args[1] == "T") {
-                cout << "tab set T <value>\n"
-                 "Temperature in Kelvin the simulation was performed\n";
-                return;
-            }
-        }
-    }
-    
-    cout << "no help text available" << endl;
+  cout << "no help text available" << endl;
 }
 
 double TabulatedPotential::getTemperature() const { return _Temperature; }
 
-pair<int,int> TabulatedPotential::getSmoothIterations() const {
-  return pair<int,int>(_tab_smooth1,_tab_smooth2);
+pair<int, int> TabulatedPotential::getSmoothIterations() const {
+  return pair<int, int>(_tab_smooth1, _tab_smooth2);
 }
 
-void TabulatedPotential::WriteHistogram(BondedStatistics &bs, vector<string> &args)
-{
-    ofstream out;
-    DataCollection<double>::selection *sel = nullptr;
+void TabulatedPotential::WriteHistogram(BondedStatistics &bs,
+                                        vector<string> &args) {
+  ofstream out;
+  DataCollection<double>::selection *sel = nullptr;
 
-    for(size_t i=1; i<args.size(); i++){
-        sel = bs.BondedValues().select(args[i], sel);
-    }
-    Histogram h(_hist_options);
-    h.ProcessData(sel);
-    out.open(args[0].c_str());
-    out << h ;
-    out.close();
-    cout << "histogram created using " << sel->size() << " data-rows, written to " << args[0] << endl;    
-    delete sel;
+  for (size_t i = 1; i < args.size(); i++) {
+    sel = bs.BondedValues().select(args[i], sel);
+  }
+  Histogram h(_hist_options);
+  h.ProcessData(sel);
+  out.open(args[0].c_str());
+  out << h;
+  out.close();
+  cout << "histogram created using " << sel->size() << " data-rows, written to "
+       << args[0] << endl;
+  delete sel;
 }
 
-void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &args)
-{
-    ofstream out;
-    DataCollection<double>::selection *sel = nullptr;
+void TabulatedPotential::WritePotential(BondedStatistics &bs,
+                                        vector<string> &args) {
+  ofstream out;
+  DataCollection<double>::selection *sel = nullptr;
 
-    // Appends all the interactions that are specified in args to selection
-    // pointer given by sel
+  // Appends all the interactions that are specified in args to selection
+  // pointer given by sel
 
-    for(size_t i=1; i<args.size(); i++){
-      sel = bs.BondedValues().select(args[i], sel);
-    }
+  for (size_t i = 1; i < args.size(); i++) {
+    sel = bs.BondedValues().select(args[i], sel);
+  }
 
-    Histogram h(_tab_options);        
-    
-    h.ProcessData(sel);
-    for(int i=0; i<_tab_smooth1; ++i){
-      Smooth_(h.getPdf(), _tab_options._periodic);
-    }
-    BoltzmannInvert_(h.getPdf());
-    for(int i=0; i<_tab_smooth2; ++i){
-        Smooth_(h.getPdf(), _tab_options._periodic);
-    }
-    out.open(args[0].c_str());
-    
-    vector<double> F;
-    assert(h.getInterval()>0 && "Interval for pdf histogram is 0");
-    CalcForce_(h.getPdf(), F, h.getInterval(), _tab_options._periodic);
-    for(int i=0; i<h.getN(); i++) {
-        out << h.getMin() + h.getInterval()*((double)i) << " " << h.getPdf()[i] << " " << F[i] << endl;
-    }
-    out.close();
-    cout << "histogram created using " << sel->size() << " data-rows, written to " << args[0] << endl;
-    delete sel;
+  Histogram h(_tab_options);
+
+  h.ProcessData(sel);
+  for (int i = 0; i < _tab_smooth1; ++i) {
+    Smooth_(h.getPdf(), _tab_options._periodic);
+  }
+  BoltzmannInvert_(h.getPdf());
+  for (int i = 0; i < _tab_smooth2; ++i) {
+    Smooth_(h.getPdf(), _tab_options._periodic);
+  }
+  out.open(args[0].c_str());
+
+  vector<double> F;
+  assert(h.getInterval() > 0 && "Interval for pdf histogram is 0");
+  CalcForce_(h.getPdf(), F, h.getInterval(), _tab_options._periodic);
+  for (int i = 0; i < h.getN(); i++) {
+    out << h.getMin() + h.getInterval() * ((double)i) << " " << h.getPdf()[i]
+        << " " << F[i] << endl;
+  }
+  out.close();
+  cout << "histogram created using " << sel->size() << " data-rows, written to "
+       << args[0] << endl;
+  delete sel;
 }
 
 /******************************************************************************
  * Private Facing Methods
  ******************************************************************************/
-bool TabulatedPotential::SetOption_(Histogram::options_t &op, const vector<string> &args)
-{
-  if(args.size() >2) {
-    if(args[1] == "n")
-      op._n = lexical_cast<int>(args[2]);       
-    else if(args[1] == "min") {
+bool TabulatedPotential::SetOption_(Histogram::options_t &op,
+                                    const vector<string> &args) {
+  if (args.size() > 2) {
+    if (args[1] == "n")
+      op._n = lexical_cast<int>(args[2]);
+    else if (args[1] == "min") {
       op._min = lexical_cast<double>(args[2]);
-    }else if(args[1] == "max") {
+    } else if (args[1] == "max") {
       op._max = lexical_cast<double>(args[2]);
-    }else if(args[1] == "periodic"){
+    } else if (args[1] == "periodic") {
       op._periodic = lexical_cast<bool>(args[2]);
-    }else if(args[1] == "auto"){
+    } else if (args[1] == "auto") {
       op._auto_interval = lexical_cast<bool>(args[2]);
-    }else if(args[1] == "extend"){
+    } else if (args[1] == "extend") {
       op._extend_interval = lexical_cast<bool>(args[2]);
-    }else if(args[1] == "normalize"){
+    } else if (args[1] == "normalize") {
       op._normalize = lexical_cast<bool>(args[2]);
-    }else if(args[1] == "scale") {
-      if(args[2]=="no" || args[2]=="bond" || args[2]=="angle"){
+    } else if (args[1] == "scale") {
+      if (args[2] == "no" || args[2] == "bond" || args[2] == "angle") {
         op._scale = args[2];
-      }else {
+      } else {
         cout << "scale can be: no, bond or angle\n";
       }
     } else {
-      return false;        
+      return false;
     }
-  }else {
+  } else {
     cout << "n: " << op._n << endl;
     cout << "min: " << op._min << endl;
     cout << "max: " << op._max << endl;
@@ -282,70 +290,71 @@ bool TabulatedPotential::SetOption_(Histogram::options_t &op, const vector<strin
   return true;
 }
 
-void TabulatedPotential::CalcForce_(vector<double> &U, vector<double> &F, double dx, bool bPeriodic)
-{
-    size_t n=U.size();
-    double f = 0.5/dx;
-    F.resize(n);
-    if(bPeriodic)
-        F[n-1] = F[0] = -(U[1] - U[n-2])*f;
-    else {
-        F[0] = -(U[1] - U[0])*2*f;
-        F[n-1] = -(U[n-1] - U[n-2])*2*f;
-    }
-    for(size_t i=1; i<n-1; i++)
-        F[i] = -(U[i+1] - U[i-1])*f;
+void TabulatedPotential::CalcForce_(vector<double> &U, vector<double> &F,
+                                    double dx, bool bPeriodic) {
+  size_t n = U.size();
+  double f = 0.5 / dx;
+  F.resize(n);
+  if (bPeriodic)
+    F[n - 1] = F[0] = -(U[1] - U[n - 2]) * f;
+  else {
+    F[0] = -(U[1] - U[0]) * 2 * f;
+    F[n - 1] = -(U[n - 1] - U[n - 2]) * 2 * f;
+  }
+  for (size_t i = 1; i < n - 1; i++)
+    F[i] = -(U[i + 1] - U[i - 1]) * f;
 }
 
-void TabulatedPotential::Smooth_(vector<double> &data, bool bPeriodic)
-{
-    double old[3];
-    int n=data.size();
-    if(bPeriodic) {
-        old[0] = data[n-3];
-        old[1] = data[n-2];
-    }
-    else {
-        old[0] = data[0];
-        old[1] = data[0];
-    }
-    size_t i;
-    for(i=0; i<data.size()-2; i++) {
-        old[2] = data[i];
-        data[i] = (old[0] + 2.*old[1] + 3.*data[i] + 2.*data[i+1] + data[i+2])/9.;
-        old[0]=old[1];
-        old[1]=old[2];;
-    }
-    if(bPeriodic) {
-        data[i] = (old[0] + 2.*old[1] + 3.*data[i] + 2.*data[i+1] + data[0])/9.;
-        old[0]=old[1];old[1]=data[i];
-        data[n-1] = data[0];
-    }
-    else {
-        data[i] = (old[0] + 2.*old[1] + 3.*data[i] + 3.*data[i+1])/9.;
-        old[0]=old[1];old[1]=data[i];
-        i++;
-        data[i] = (old[0] + 2.*old[1] + 6.*data[i])/9.;    
-    }
+void TabulatedPotential::Smooth_(vector<double> &data, bool bPeriodic) {
+  double old[3];
+  int n = data.size();
+  if (bPeriodic) {
+    old[0] = data[n - 3];
+    old[1] = data[n - 2];
+  } else {
+    old[0] = data[0];
+    old[1] = data[0];
+  }
+  size_t i;
+  for (i = 0; i < data.size() - 2; i++) {
+    old[2] = data[i];
+    data[i] = (old[0]+2.*old[1]+3.*data[i]+2.*data[i+1]+data[i + 2])/9.;
+    old[0] = old[1];
+    old[1] = old[2];
+    ;
+  }
+  if (bPeriodic) {
+    data[i] = (old[0]+2.*old[1]+3.*data[i]+2.*data[i+1]+data[0])/9.;
+    old[0] = old[1];
+    old[1] = data[i];
+    data[n - 1] = data[0];
+  } else {
+    data[i] = (old[0]+2.*old[1]+3.*data[i]+3.*data[i+1])/9.;
+    old[0] = old[1];
+    old[1] = data[i];
+    i++;
+    data[i] = (old[0]+2.*old[1]+6.*data[i]) / 9.;
+  }
 }
 
-void TabulatedPotential::BoltzmannInvert_(vector<double> &data)
-{
-    double _min, _max;
-    
-    _min = numeric_limits<double>::max();
-    _max = numeric_limits<double>::min();
-    
-    for(size_t i=0; i<data.size(); i++) {
-        _max = max(data[i], _max);
-        if(data[i] > 0) _min = min(data[i], _min);
-    }
-    _max = -kB*_Temperature*log(_max);
-    _min = -kB*_Temperature*log(_min)-_max;
-    
-    for(size_t i=0; i<data.size(); i++) {
-        if(data[i] == 0) data[i] = _min;
-        else
-            data[i] = -kB*_Temperature*log(data[i]) - _max;
-    }
+void TabulatedPotential::BoltzmannInvert_(vector<double> &data) {
+  double _min, _max;
+
+  _min = numeric_limits<double>::max();
+  _max = numeric_limits<double>::min();
+
+  for (size_t i = 0; i < data.size(); i++) {
+    _max = max(data[i], _max);
+    if (data[i] > 0)
+      _min = min(data[i], _min);
+  }
+  _max = -kB * _Temperature * log(_max);
+  _min = -kB * _Temperature * log(_min) - _max;
+
+  for (size_t i = 0; i < data.size(); i++) {
+    if (data[i] == 0)
+      data[i] = _min;
+    else
+      data[i] = -kB * _Temperature * log(data[i]) - _max;
+  }
 }

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -29,10 +29,10 @@
 #include <votca/tools/constants.h>
 
 using namespace std;
-using namespace boost;
 using namespace votca::tools;
-using namespace votca::csg;
 
+namespace votca {
+  namespace csg {
 /******************************************************************************
  * Public Facing Methods
  ******************************************************************************/
@@ -55,11 +55,11 @@ void TabulatedPotential::Command(BondedStatistics &bs, string cmd,
       if (!SetOption_(_tab_options, args)) {
         if (args.size() > 2) {
           if (args[1] == "smooth_pdf") {
-            _tab_smooth1 = lexical_cast<int>(args[2]);
+            _tab_smooth1 = boost::lexical_cast<int>(args[2]);
           } else if (args[1] == "smooth_pot") {
-            _tab_smooth2 = lexical_cast<int>(args[2]);
+            _tab_smooth2 = boost::lexical_cast<int>(args[2]);
           } else if (args[1] == "T") {
-            _Temperature = lexical_cast<double>(args[2]);
+            _Temperature = boost::lexical_cast<double>(args[2]);
           } else {
             cout << "unknown option " << args[2] << endl;
             return;
@@ -255,19 +255,19 @@ bool TabulatedPotential::SetOption_(Histogram::options_t &op,
                                     const vector<string> &args) {
   if (args.size() > 2) {
     if (args[1] == "n")
-      op._n = lexical_cast<int>(args[2]);
+      op._n = boost::lexical_cast<int>(args[2]);
     else if (args[1] == "min") {
-      op._min = lexical_cast<double>(args[2]);
+      op._min = boost::lexical_cast<double>(args[2]);
     } else if (args[1] == "max") {
-      op._max = lexical_cast<double>(args[2]);
+      op._max = boost::lexical_cast<double>(args[2]);
     } else if (args[1] == "periodic") {
-      op._periodic = lexical_cast<bool>(args[2]);
+      op._periodic = boost::lexical_cast<bool>(args[2]);
     } else if (args[1] == "auto") {
-      op._auto_interval = lexical_cast<bool>(args[2]);
+      op._auto_interval = boost::lexical_cast<bool>(args[2]);
     } else if (args[1] == "extend") {
-      op._extend_interval = lexical_cast<bool>(args[2]);
+      op._extend_interval = boost::lexical_cast<bool>(args[2]);
     } else if (args[1] == "normalize") {
-      op._normalize = lexical_cast<bool>(args[2]);
+      op._normalize = boost::lexical_cast<bool>(args[2]);
     } else if (args[1] == "scale") {
       if (args[2] == "no" || args[2] == "bond" || args[2] == "angle") {
         op._scale = args[2];
@@ -358,3 +358,5 @@ void TabulatedPotential::BoltzmannInvert_(vector<double> &data) {
       data[i] = -conv::kB*conv::ev2kj_per_mol * _Temperature * log(data[i]) - _max;
   }
 }
+
+}}

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -29,6 +29,8 @@
 
 using namespace std;
 using namespace boost;
+using namespace votca::tools;
+using namespace votca::csg;
 
 /* Boltzmann constant in units [ kJ/(mol K) ] */
 const double kB = 0.0083109;

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -52,9 +52,9 @@ void TabulatedPotential::Command(BondedStatistics &bs, string cmd, vector<string
 {
   if(args[0]=="set") {
     if(cmd=="hist") {
-      SetOption(_hist_options, args);
+      SetOption_(_hist_options, args);
     }else if(cmd=="tab") {
-      if(!SetOption(_tab_options, args)) {
+      if(!SetOption_(_tab_options, args)) {
         if(args.size() >2) {
           if(args[1]=="smooth_pdf"){
             _tab_smooth1 = lexical_cast<int>(args[2]);       
@@ -216,18 +216,18 @@ void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &ar
     Histogram h(_tab_options);
     h.ProcessData(sel);
     for(int i=0; i<_tab_smooth1; ++i){
-      Smooth(h.getPdf(), _tab_options._periodic);
+      Smooth_(h.getPdf(), _tab_options._periodic);
     }
-    BoltzmannInvert(h.getPdf());
+    BoltzmannInvert_(h.getPdf());
     for(int i=0; i<_tab_smooth2; ++i){
-        Smooth(h.getPdf(), _tab_options._periodic);
+        Smooth_(h.getPdf(), _tab_options._periodic);
     }
     cout << "Writing Potential to file arg0 " << args[0].c_str() << endl;
     out.open(args[0].c_str());
     
     vector<double> F;
     
-    CalcForce(h.getPdf(), F, h.getInterval(), _tab_options._periodic);
+    CalcForce_(h.getPdf(), F, h.getInterval(), _tab_options._periodic);
     for(int i=0; i<h.getN(); i++) {
         out << h.getMin() + h.getInterval()*((double)i) << " " << h.getPdf()[i] << " " << F[i] << endl;
     }
@@ -277,7 +277,6 @@ bool TabulatedPotential::SetOption_(Histogram::options_t &op, const vector<strin
   }
   return true;
 }
-
 
 void TabulatedPotential::CalcForce_(vector<double> &U, vector<double> &F, double dx, bool bPeriodic)
 {

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -33,10 +33,13 @@ using namespace boost;
 /* Boltzmann constant in units [ kJ/(mol K) ] */
 const double kB = 0.0083109;
 
+/******************************************************************************
+ * Public Facing Methods
+ ******************************************************************************/
 TabulatedPotential::TabulatedPotential()
 {
     _tab_smooth1 = _tab_smooth2 = 0;
-    _T = 300;
+    _Temperature = 300;
 }
 
 void TabulatedPotential::Register(map<string, AnalysisTool *> &lib)
@@ -47,35 +50,39 @@ void TabulatedPotential::Register(map<string, AnalysisTool *> &lib)
 
 void TabulatedPotential::Command(BondedStatistics &bs, string cmd, vector<string> &args)
 {
-    if(args[0] == "set") {
-        if(cmd == "hist") SetOption(_hist_options, args);
-        else if(cmd == "tab") {
-            if(!SetOption(_tab_options, args)) {
-                if(args.size() >2) {
-                    if(args[1] == "smooth_pdf")
-                        _tab_smooth1 = lexical_cast<int>(args[2]);       
-                    else if(args[1] == "smooth_pot")
-                        _tab_smooth2 = lexical_cast<int>(args[2]);       
-                    else if(args[1] == "T")
-                        _T = lexical_cast<double>(args[2]);
-                    else {
-                        cout << "unknown option " << args[2] << endl;
-                        return;
-                    }
-                }
-            }        
-            if(args.size() <=2) {
-                cout << "smooth_pdf: " << _tab_smooth1 << endl;
-                cout << "smooth_pot: " << _tab_smooth2 << endl;
-                cout << "T: " << _T << endl;
-            }
+  if(args[0]=="set") {
+    if(cmd=="hist") {
+      SetOption(_hist_options, args);
+    }else if(cmd=="tab") {
+      if(!SetOption(_tab_options, args)) {
+        if(args.size() >2) {
+          if(args[1]=="smooth_pdf"){
+            _tab_smooth1 = lexical_cast<int>(args[2]);       
+          }else if(args[1]=="smooth_pot"){
+            _tab_smooth2 = lexical_cast<int>(args[2]);       
+          } else if(args[1]=="T"){
+            _Temperature = lexical_cast<double>(args[2]);
+          }else {
+            cout << "unknown option " << args[2] << endl;
+            return;
+          }
         }
+      }        
+      if(args.size() <=2) {
+        cout << "smooth_pdf: " << _tab_smooth1 << endl;
+        cout << "smooth_pot: " << _tab_smooth2 << endl;
+        cout << "T: " << _Temperature << endl;
+      }
     }
-    else if(args.size() >= 2) {
-        if(cmd == "hist") WriteHistogram(bs, args);
-        else if(cmd == "tab") WritePotential(bs, args);
+  }else if(args.size() >= 2) {
+    if(cmd=="hist"){ 
+      WriteHistogram(bs, args);
+    }else if(cmd=="tab"){ 
+      WritePotential(bs, args);
     }
-    else cout << "wrong number of arguments" << endl;
+  }else{ 
+    cout << "wrong number of arguments" << endl;
+  }
 }
 
 
@@ -175,74 +182,55 @@ void TabulatedPotential::Help(string cmd, vector<string> &args)
     cout << "no help text available" << endl;
 }
 
-bool TabulatedPotential::SetOption(Histogram::options_t &op, const vector<string> &args)
-//bool TabulatedPotential::SetOption(const vector<string> &args)
-{
-/*  int number_of_bins = 0;
-  double minimum_value = 0.0;
-  double maximum_value = 0.0;
-  bool make_periodic = false;
-  bool auto_interval = false;
-  bool extend_interval = false;
-  bool normalize = false;
-  string scale = "";*/
-  if(args.size() >2) {
-        if(args[1] == "n")
-            op._n = lexical_cast<int>(args[2]);       
-            //number_of_bins = lexical_cast<int>(args[2]);       
-        else if(args[1] == "min") {
-            op._min = lexical_cast<double>(args[2]);
-            //minimum_value = lexical_cast<double>(args[2]);
-        }
-        else if(args[1] == "max")
-            op._max = lexical_cast<double>(args[2]);
-            //maximum_value = lexical_cast<double>(args[2]);
-        else if(args[1] == "periodic")
-            op._periodic = lexical_cast<bool>(args[2]);
-            //make_periodic = lexical_cast<bool>(args[2]);
-        else if(args[1] == "auto")
-            op._auto_interval = lexical_cast<bool>(args[2]);
-            //auto_interval = lexical_cast<bool>(args[2]);
-        else if(args[1] == "extend")
-            op._extend_interval = lexical_cast<bool>(args[2]);
-            //extend_interval = lexical_cast<bool>(args[2]);
-        else if(args[1] == "normalize")
-            //normalize = lexical_cast<bool>(args[2]);
-            op._normalize = lexical_cast<bool>(args[2]);
-        else if(args[1] == "scale") {
-            if(args[2]=="no" || args[2]=="bond" || args[2]=="angle")
-                //scale = args[2];
-                op._scale = args[2];
-            else {
-                cout << "scale can be: no, bond or angle\n";
-            }
-        }
-        else {
-            return false;        
-        }
-    }
-    else {
-/*        cout << "n: " << number_of_bins << endl;
-        cout << "min: " << minimum_value << endl;
-        cout << "max: " << maximum_value << endl;
-        cout << "periodic: " << periodic << endl;
-        cout << "auto: " << auto_interval << endl;
-        cout << "extend: " << extend_interval << endl;
-        cout << "scale: " << scale << endl;
-        cout << "normalize: " << normalize << endl;*/
-        cout << "n: " << op._n << endl;
-        cout << "min: " << op._min << endl;
-        cout << "max: " << op._max << endl;
-        cout << "periodic: " << op._periodic << endl;
-        cout << "auto: " << op._auto_interval << endl;
-        cout << "extend: " << op._extend_interval << endl;
-        cout << "scale: " << op._scale << endl;
-        cout << "normalize: " << op._normalize << endl;
-    }
-    return true;
+double TabulatedPotential::getTemperature() const { return _Temperature; }
+
+pair<int,int> TabulatedPotential::getSmoothIterations() const {
+  return pair<int,int>(_tab_smooth1,_tab_smooth2);
 }
 
-void TabulatedPotential::WriteHistogram(BondedStatistics &bs, vector<string> &args)
+/******************************************************************************
+ * Private Facing Methods
+ ******************************************************************************/
+bool TabulatedPotential::SetOption_(Histogram::options_t &op, const vector<string> &args)
+{
+  if(args.size() >2) {
+    if(args[1] == "n")
+      op._n = lexical_cast<int>(args[2]);       
+    else if(args[1] == "min") {
+      op._min = lexical_cast<double>(args[2]);
+    }else if(args[1] == "max") {
+      op._max = lexical_cast<double>(args[2]);
+    }else if(args[1] == "periodic"){
+      op._periodic = lexical_cast<bool>(args[2]);
+    }else if(args[1] == "auto"){
+      op._auto_interval = lexical_cast<bool>(args[2]);
+    }else if(args[1] == "extend"){
+      op._extend_interval = lexical_cast<bool>(args[2]);
+    }else if(args[1] == "normalize"){
+      op._normalize = lexical_cast<bool>(args[2]);
+    }else if(args[1] == "scale") {
+      if(args[2]=="no" || args[2]=="bond" || args[2]=="angle"){
+        op._scale = args[2];
+      }else {
+        cout << "scale can be: no, bond or angle\n";
+      }
+    } else {
+      return false;        
+    }
+  }else {
+    cout << "n: " << op._n << endl;
+    cout << "min: " << op._min << endl;
+    cout << "max: " << op._max << endl;
+    cout << "periodic: " << op._periodic << endl;
+    cout << "auto: " << op._auto_interval << endl;
+    cout << "extend: " << op._extend_interval << endl;
+    cout << "scale: " << op._scale << endl;
+    cout << "normalize: " << op._normalize << endl;
+  }
+  return true;
+}
+
+void TabulatedPotential::WriteHistogram_(BondedStatistics &bs, vector<string> &args)
 {
     ofstream out;
     DataCollection<double>::selection *sel = NULL;
@@ -259,7 +247,7 @@ void TabulatedPotential::WriteHistogram(BondedStatistics &bs, vector<string> &ar
 }
 
 
-void TabulatedPotential::CalcForce(vector<double> &U, vector<double> &F, double dx, bool bPeriodic)
+void TabulatedPotential::CalcForce_(vector<double> &U, vector<double> &F, double dx, bool bPeriodic)
 {
     size_t n=U.size();
     double f = 0.5/dx;
@@ -274,22 +262,25 @@ void TabulatedPotential::CalcForce(vector<double> &U, vector<double> &F, double 
         F[i] = -(U[i+1] - U[i-1])*f;
 }
 
-void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &args)
+void TabulatedPotential::WritePotential_(BondedStatistics &bs, vector<string> &args)
 {
-   ofstream out;
+    cout << "Writing Potential " << endl;
+    ofstream out;
     DataCollection<double>::selection *sel = NULL;
 
-    for(size_t i=1; i<args.size(); i++)
-        sel = bs.BondedValues().select(args[i], sel);
+    for(size_t i=1; i<args.size(); i++){
+      sel = bs.BondedValues().select(args[i], sel);
+    }
     Histogram h(_tab_options);
     h.ProcessData(sel);
     for(int i=0; i<_tab_smooth1; ++i){
-        Smooth(h.getPdf(), _tab_options._periodic);
+      Smooth(h.getPdf(), _tab_options._periodic);
     }
     BoltzmannInvert(h.getPdf());
     for(int i=0; i<_tab_smooth2; ++i){
         Smooth(h.getPdf(), _tab_options._periodic);
     }
+    cout << "Writing Potential to file arg0 " << args[0].c_str() << endl;
     out.open(args[0].c_str());
     
     vector<double> F;
@@ -303,7 +294,7 @@ void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &ar
     delete sel;
 }
 
-void TabulatedPotential::Smooth(vector<double> &data, bool bPeriodic)
+void TabulatedPotential::Smooth_(vector<double> &data, bool bPeriodic)
 {
     double old[3];
     int n=data.size();
@@ -335,7 +326,7 @@ void TabulatedPotential::Smooth(vector<double> &data, bool bPeriodic)
     }
 }
 
-void TabulatedPotential::BoltzmannInvert(vector<double> &data)
+void TabulatedPotential::BoltzmannInvert_(vector<double> &data)
 {
     double _min, _max;
     
@@ -346,8 +337,8 @@ void TabulatedPotential::BoltzmannInvert(vector<double> &data)
         _max = max(data[i], _max);
         if(data[i] > 0) _min = min(data[i], _min);
     }
-    _max = -kB*T*log(_max);
-    _min = -kB*T*log(_min)-_max;
+    _max = -kB*_Temperature*log(_max);
+    _min = -kB*_Temperature*log(_min)-_max;
     
     for(size_t i=0; i<data.size(); i++) {
         if(data[i] == 0) data[i] = _min;

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -191,10 +191,11 @@ pair<int,int> TabulatedPotential::getSmoothIterations() const {
 void TabulatedPotential::WriteHistogram(BondedStatistics &bs, vector<string> &args)
 {
     ofstream out;
-    DataCollection<double>::selection *sel = NULL;
+    DataCollection<double>::selection *sel = nullptr;
 
-    for(size_t i=1; i<args.size(); i++)
+    for(size_t i=1; i<args.size(); i++){
         sel = bs.BondedValues().select(args[i], sel);
+    }
     Histogram h(_hist_options);
     h.ProcessData(sel);
     out.open(args[0].c_str());
@@ -206,14 +207,18 @@ void TabulatedPotential::WriteHistogram(BondedStatistics &bs, vector<string> &ar
 
 void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &args)
 {
-    cout << "Writing Potential " << endl;
     ofstream out;
-    DataCollection<double>::selection *sel = NULL;
+    DataCollection<double>::selection *sel = nullptr;
+
+    // Appends all the interactions that are specified in args to selection
+    // pointer given by sel
 
     for(size_t i=1; i<args.size(); i++){
       sel = bs.BondedValues().select(args[i], sel);
     }
-    Histogram h(_tab_options);
+
+    Histogram h(_tab_options);        
+    
     h.ProcessData(sel);
     for(int i=0; i<_tab_smooth1; ++i){
       Smooth_(h.getPdf(), _tab_options._periodic);
@@ -222,11 +227,10 @@ void TabulatedPotential::WritePotential(BondedStatistics &bs, vector<string> &ar
     for(int i=0; i<_tab_smooth2; ++i){
         Smooth_(h.getPdf(), _tab_options._periodic);
     }
-    cout << "Writing Potential to file arg0 " << args[0].c_str() << endl;
     out.open(args[0].c_str());
     
     vector<double> F;
-    
+    assert(h.getInterval()>0 && "Interval for pdf histogram is 0");
     CalcForce_(h.getPdf(), F, h.getInterval(), _tab_options._periodic);
     for(int i=0; i<h.getN(); i++) {
         out << h.getMin() + h.getInterval()*((double)i) << " " << h.getPdf()[i] << " " << F[i] << endl;

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -26,14 +26,12 @@
 #include <vector>
 #include <votca/csg/version.h>
 #include <votca/tools/histogram.h>
+#include <votca/tools/constants.h>
 
 using namespace std;
 using namespace boost;
 using namespace votca::tools;
 using namespace votca::csg;
-
-/* Boltzmann constant in units [ kJ/(mol K) ] */
-const double kB = 0.0083109;
 
 /******************************************************************************
  * Public Facing Methods
@@ -350,13 +348,13 @@ void TabulatedPotential::BoltzmannInvert_(vector<double> &data) {
     if (data[i] > 0)
       _min = min(data[i], _min);
   }
-  _max = -kB * _Temperature * log(_max);
-  _min = -kB * _Temperature * log(_min) - _max;
+  _max = -conv::kB*conv::ev2kj_per_mol * _Temperature * log(_max);
+  _min = -conv::kB*conv::ev2kj_per_mol * _Temperature * log(_min) - _max;
 
   for (size_t i = 0; i < data.size(); i++) {
     if (data[i] == 0)
       data[i] = _min;
     else
-      data[i] = -kB * _Temperature * log(data[i]) - _max;
+      data[i] = -conv::kB*conv::ev2kj_per_mol * _Temperature * log(data[i]) - _max;
   }
 }

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -23,10 +23,6 @@
 #include <vector>
 #include <votca/tools/histogram.h>
 
-using namespace std;
-using namespace votca::tools;
-using namespace votca::csg;
-
 /**
  * \brief Tabulated Potential calculates histograms of bead interactions
  *

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -43,9 +43,28 @@ class TabulatedPotential
         void WriteHistogram(BondedStatistics &bs, vector<string> &args);
         void WritePotential(BondedStatistics &bs, vector<string> &args);
 
+        /**
+         * \brief Returns the temperature used during the bolzmann inversion 
+         *
+         * \return temperature in kelvin
+         **/
+        double getTemperature() const;
+
+        /**
+         * \brief Method returns the number of smoothing iterations used on the
+         * data
+         *
+         * The first integer is the number of smoothing iterations before 
+         * boltzmann inversion is done, and the second interger is the number
+         * of iterations done on the boltzmann inverted histogram. 
+         *
+         * \return pair of integers containing the number of smoothing 
+         * iteratiosn before and after boltzmann inversion.
+         **/
+        std::pair<int,int> getSmoothIterations() const;
     private:
-        bool SetOption(Histogram::options_t &op, const vector<string> &args);
-        bool SetOption(const vector<string> &args);
+        bool SetOption_(Histogram::options_t &op, const vector<string> &args);
+        bool SetOption_(const vector<string> &args);
 
         /**
          * \brief Smooths a vector of doubles
@@ -58,9 +77,9 @@ class TabulatedPotential
          * \param[in] periodic boolean determining if the smoothing will use
          * periodic boundary conditions
          **/
-        void Smooth(vector<double> &data, bool bPeriodic);
-        void BoltzmannInvert(vector<double> &data);
-        void CalcForce(vector<double> &u, vector<double> &du, double dx, bool bPeriodic);
+        void Smooth_(vector<double> &data, bool bPeriodic);
+        void BoltzmannInvert_(vector<double> &data);
+        void CalcForce_(vector<double> &u, vector<double> &du, double dx, bool bPeriodic);
 
         Histogram::options_t _tab_options;
         Histogram::options_t _hist_options;

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -15,13 +15,12 @@
  *
  */
 
-#ifndef _TABULATEDPOTENTIAL_H
-#define	_TABULATEDPOTENTIAL_H
+#ifndef VOTCA_CSG_TABULATEDPOTENTIAL_H
+#define	VOTCA_CSG_TABULATEDPOTENTIAL_H
 
 #include <vector>
 #include "bondedstatistics.h"
 #include "analysistool.h"
-//#include <votca/tools/histogramnew.h>
 #include <votca/tools/histogram.h>
 
 using namespace std;
@@ -167,8 +166,7 @@ class TabulatedPotential
         /// Temperature in units of Kelvin
         double _Temperature;
 
-//        HistogramNew _hist;
 };
 
-#endif	/* _TABULATEDPOTENTIAL_H */
+#endif	// VOTCA_CSG_TABULATEDPOTENTIAL_H
 

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -20,6 +20,8 @@
 
 #include <vector>
 #include "bondedstatistics.h"
+#include "analysistool.h"
+//#include <votca/tools/histogramnew.h>
 #include <votca/tools/histogram.h>
 
 using namespace std;
@@ -43,15 +45,36 @@ class TabulatedPotential
 
     private:
         bool SetOption(Histogram::options_t &op, const vector<string> &args);
+        bool SetOption(const vector<string> &args);
+
+        /**
+         * \brief Smooths a vector of doubles
+         *
+         * This function uses a weighted smoothing algorithm using 5 data 
+         * points, the weights are applied as 1:2:3:2:1 where the middle point
+         * becomes the average of these weighted values.
+         *
+         * \param[in,out] data vector of doubles that is smoothed
+         * \param[in] periodic boolean determining if the smoothing will use
+         * periodic boundary conditions
+         **/
         void Smooth(vector<double> &data, bool bPeriodic);
-        void BoltzmannInvert(vector<double> &data, double T);
+        void BoltzmannInvert(vector<double> &data);
         void CalcForce(vector<double> &u, vector<double> &du, double dx, bool bPeriodic);
 
         Histogram::options_t _tab_options;
         Histogram::options_t _hist_options;
+
+        /// How many times the data is smoothed before the histogram is 
+        /// boltzmann inverted.
         int _tab_smooth1;
+        /// How many times the data is smoothed after the histogram is boltzmann
+        /// inverted.
         int _tab_smooth2;
-        double _T;
+        /// Temperature in units of Kelvin
+        double _Temperature;
+
+//        HistogramNew _hist;
 };
 
 #endif	/* _TABULATEDPOTENTIAL_H */

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,11 @@
  */
 
 #ifndef VOTCA_CSG_TABULATEDPOTENTIAL_H
-#define	VOTCA_CSG_TABULATEDPOTENTIAL_H
+#define VOTCA_CSG_TABULATEDPOTENTIAL_H
 
-#include <vector>
-#include "bondedstatistics.h"
 #include "analysistool.h"
+#include "bondedstatistics.h"
+#include <vector>
 #include <votca/tools/histogram.h>
 
 using namespace std;
@@ -32,15 +32,15 @@ using namespace votca::csg;
  *
  * There are two histograms that can be created:
  *
- * * the first is a potential distribution table specified with the 'tab' 
- * keyword (for table). This uses boltzmann inversion to calculate the 
+ * * the first is a potential distribution table specified with the 'tab'
+ * keyword (for table). This uses boltzmann inversion to calculate the
  * potential from a selection of bead interactions.
  *
- * * the second is a histogram of the beads interactions specified with the 
- * 'hist' keyword. 
+ * * the second is a histogram of the beads interactions specified with the
+ * 'hist' keyword.
  *
  * As an example let us assume we already have a BondedStatistics object named
- * 'bonded_statistics' with the correct data. We can write a histogram of the 
+ * 'bonded_statistics' with the correct data. We can write a histogram of the
  * interactions using the following commands:
  *
  *     TabulatedPotential tabulated_potential;
@@ -58,13 +58,13 @@ using namespace votca::csg;
  * The above example creates the object it then proceeds to set one of the
  * properties of the histogram. In this case the number of data points is
  * specified with the keyword 'n', the 11 indicates we want the histogram to
- * consist of 11 bins. To actually create the histogram the Command method is 
+ * consist of 11 bins. To actually create the histogram the Command method is
  * called a second time but because the 'set' keyword is not the first element
  * in the vector of strings the tabulated potential object assumes it is a file
  * name were the histogram will be written. The following labels ("bond1",
- * "bond2", etc...) specify the interactions to be sorted into the histogram. 
- * Running this code should produce a file named file1.txt containing two 
- * columns. 
+ * "bond2", etc...) specify the interactions to be sorted into the histogram.
+ * Running this code should produce a file named file1.txt containing two
+ * columns.
  *
  * column1 = the bin edge, column2 = the contents of the histogram
  *
@@ -87,86 +87,84 @@ using namespace votca::csg;
  *     vector<string> interactions{"file2.txt","bond1","bond2","bond3",...};
  *     tabulated_potential.Command(bonded_statistics,"tab",interactions);
  *
- * Here, notice we are using the 'tab' keyword to indicate it is for the 
+ * Here, notice we are using the 'tab' keyword to indicate it is for the
  * tabulated potential. We are also setting several properities. The temperature
  * is changed from the default 300 Kelvin to 275 Kelvin. Smooth potential is set
  * to 1 this has the affect of smoothing the potential after boltzmann inversion
  * is done. If a value greater than 1 were used it would smooth the data several
- * times upto the number specified. And the final setting was to make the 
+ * times upto the number specified. And the final setting was to make the
  * tabulated potential periodic. The value "1" is converted to a boolean which
- * is interpreted as true. 
+ * is interpreted as true.
  *
- * Finally, the data is printed to a file called "file2.txt" which contains 
+ * Finally, the data is printed to a file called "file2.txt" which contains
  * three columns:
- * 
+ *
  * column1 = the bin edge, column2 = potential, column3 = the force
  **/
-class TabulatedPotential
-    : public AnalysisTool
-{
-    public:
-        TabulatedPotential();
-        ~TabulatedPotential() {};
+class TabulatedPotential : public AnalysisTool {
+public:
+  TabulatedPotential();
+  ~TabulatedPotential(){};
 
-        void Register(map<string, AnalysisTool *> &lib);
+  void Register(map<string, AnalysisTool *> &lib);
 
-        void Command(BondedStatistics &bs, string cmd, vector<string> &args);
-        void Help(string cmd, vector<string> &args);
+  void Command(BondedStatistics &bs, string cmd, vector<string> &args);
+  void Help(string cmd, vector<string> &args);
 
-        void WriteHistogram(BondedStatistics &bs, vector<string> &args);
-        void WritePotential(BondedStatistics &bs, vector<string> &args);
+  void WriteHistogram(BondedStatistics &bs, vector<string> &args);
+  void WritePotential(BondedStatistics &bs, vector<string> &args);
 
-        /**
-         * \brief Returns the temperature used during the bolzmann inversion 
-         *
-         * \return temperature in kelvin
-         **/
-        double getTemperature() const;
+  /**
+   * \brief Returns the temperature used during the bolzmann inversion
+   *
+   * \return temperature in kelvin
+   **/
+  double getTemperature() const;
 
-        /**
-         * \brief Method returns the number of smoothing iterations used on the
-         * data
-         *
-         * The first integer is the number of smoothing iterations before 
-         * boltzmann inversion is done, and the second interger is the number
-         * of iterations done on the boltzmann inverted histogram. 
-         *
-         * \return pair of integers containing the number of smoothing 
-         * iteratiosn before and after boltzmann inversion.
-         **/
-        std::pair<int,int> getSmoothIterations() const;
-    private:
-        bool SetOption_(Histogram::options_t &op, const vector<string> &args);
-        bool SetOption_(const vector<string> &args);
+  /**
+   * \brief Method returns the number of smoothing iterations used on the
+   * data
+   *
+   * The first integer is the number of smoothing iterations before
+   * boltzmann inversion is done, and the second interger is the number
+   * of iterations done on the boltzmann inverted histogram.
+   *
+   * \return pair of integers containing the number of smoothing
+   * iteratiosn before and after boltzmann inversion.
+   **/
+  std::pair<int, int> getSmoothIterations() const;
 
-        /**
-         * \brief Smooths a vector of doubles
-         *
-         * This function uses a weighted smoothing algorithm using 5 data 
-         * points, the weights are applied as 1:2:3:2:1 where the middle point
-         * becomes the average of these weighted values.
-         *
-         * \param[in,out] data vector of doubles that is smoothed
-         * \param[in] periodic boolean determining if the smoothing will use
-         * periodic boundary conditions
-         **/
-        void Smooth_(vector<double> &data, bool bPeriodic);
-        void BoltzmannInvert_(vector<double> &data);
-        void CalcForce_(vector<double> &u, vector<double> &du, double dx, bool bPeriodic);
+private:
+  bool SetOption_(Histogram::options_t &op, const vector<string> &args);
+  bool SetOption_(const vector<string> &args);
 
-        Histogram::options_t _tab_options;
-        Histogram::options_t _hist_options;
+  /**
+   * \brief Smooths a vector of doubles
+   *
+   * This function uses a weighted smoothing algorithm using 5 data
+   * points, the weights are applied as 1:2:3:2:1 where the middle point
+   * becomes the average of these weighted values.
+   *
+   * \param[in,out] data vector of doubles that is smoothed
+   * \param[in] periodic boolean determining if the smoothing will use
+   * periodic boundary conditions
+   **/
+  void Smooth_(vector<double> &data, bool bPeriodic);
+  void BoltzmannInvert_(vector<double> &data);
+  void CalcForce_(vector<double> &u, vector<double> &du, double dx,
+                  bool bPeriodic);
 
-        /// How many times the data is smoothed before the histogram is 
-        /// boltzmann inverted.
-        int _tab_smooth1;
-        /// How many times the data is smoothed after the histogram is boltzmann
-        /// inverted.
-        int _tab_smooth2;
-        /// Temperature in units of Kelvin
-        double _Temperature;
+  Histogram::options_t _tab_options;
+  Histogram::options_t _hist_options;
 
+  /// How many times the data is smoothed before the histogram is
+  /// boltzmann inverted.
+  int _tab_smooth1;
+  /// How many times the data is smoothed after the histogram is boltzmann
+  /// inverted.
+  int _tab_smooth2;
+  /// Temperature in units of Kelvin
+  double _Temperature;
 };
 
-#endif	// VOTCA_CSG_TABULATEDPOTENTIAL_H
-
+#endif // VOTCA_CSG_TABULATEDPOTENTIAL_H

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -23,8 +23,10 @@
 #include <vector>
 #include <votca/tools/histogram.h>
 
-namespace CSG = votca::csg;
 namespace TOOLS = votca::tools;
+
+namespace votca {
+  namespace csg {
 /**
  * \brief Tabulated Potential calculates histograms of bead interactions
  *
@@ -168,5 +170,5 @@ private:
   /// Temperature in units of Kelvin
   double _Temperature;
 };
-
+}}
 #endif // VOTCA_CSG_TABULATEDPOTENTIAL_H

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -23,6 +23,8 @@
 #include <vector>
 #include <votca/tools/histogram.h>
 
+namespace CSG = votca::csg;
+namespace TOOLS = votca::tools;
 /**
  * \brief Tabulated Potential calculates histograms of bead interactions
  *
@@ -102,13 +104,15 @@ public:
   TabulatedPotential();
   ~TabulatedPotential(){};
 
-  void Register(map<string, AnalysisTool *> &lib);
+  void Register(std::map<std::string, AnalysisTool *> &lib);
 
-  void Command(BondedStatistics &bs, string cmd, vector<string> &args);
-  void Help(string cmd, vector<string> &args);
+  void Command(BondedStatistics &bs, std::string cmd, 
+      std::vector<std::string> &args);
 
-  void WriteHistogram(BondedStatistics &bs, vector<string> &args);
-  void WritePotential(BondedStatistics &bs, vector<string> &args);
+  void Help(std::string cmd, std::vector<std::string> &args);
+
+  void WriteHistogram(BondedStatistics &bs, std::vector<std::string> &args);
+  void WritePotential(BondedStatistics &bs, std::vector<std::string> &args);
 
   /**
    * \brief Returns the temperature used during the bolzmann inversion
@@ -131,8 +135,10 @@ public:
   std::pair<int, int> getSmoothIterations() const;
 
 private:
-  bool SetOption_(Histogram::options_t &op, const vector<string> &args);
-  bool SetOption_(const vector<string> &args);
+  bool SetOption_(TOOLS::Histogram::options_t &op, 
+      const std::vector<std::string> &args);
+
+  bool SetOption_(const std::vector<std::string> &args);
 
   /**
    * \brief Smooths a vector of doubles
@@ -145,13 +151,13 @@ private:
    * \param[in] periodic boolean determining if the smoothing will use
    * periodic boundary conditions
    **/
-  void Smooth_(vector<double> &data, bool bPeriodic);
-  void BoltzmannInvert_(vector<double> &data);
-  void CalcForce_(vector<double> &u, vector<double> &du, double dx,
+  void Smooth_(std::vector<double> &data, bool bPeriodic);
+  void BoltzmannInvert_(std::vector<double> &data);
+  void CalcForce_(std::vector<double> &u, std::vector<double> &du, double dx,
                   bool bPeriodic);
 
-  Histogram::options_t _tab_options;
-  Histogram::options_t _hist_options;
+  TOOLS::Histogram::options_t _tab_options;
+  TOOLS::Histogram::options_t _hist_options;
 
   /// How many times the data is smoothed before the histogram is
   /// boltzmann inverted.

--- a/src/csg_boltzmann/tabulatedpotential.h
+++ b/src/csg_boltzmann/tabulatedpotential.h
@@ -28,6 +28,80 @@ using namespace std;
 using namespace votca::tools;
 using namespace votca::csg;
 
+/**
+ * \brief Tabulated Potential calculates histograms of bead interactions
+ *
+ * There are two histograms that can be created:
+ *
+ * * the first is a potential distribution table specified with the 'tab' 
+ * keyword (for table). This uses boltzmann inversion to calculate the 
+ * potential from a selection of bead interactions.
+ *
+ * * the second is a histogram of the beads interactions specified with the 
+ * 'hist' keyword. 
+ *
+ * As an example let us assume we already have a BondedStatistics object named
+ * 'bonded_statistics' with the correct data. We can write a histogram of the 
+ * interactions using the following commands:
+ *
+ *     TabulatedPotential tabulated_potential;
+ *
+ *     map<string,AnalysisTool *> commands;
+ *     tabulated_potential.Register(commands);
+ *
+ *     vector<string> arguments{"set","n","11"};
+ *
+ *     tabulated_potential.Command(bonded_statistics,"hist",arguments);
+ *
+ *     vector<string> interactions{"file1.txt","bond1","bond2","bond3",...};
+ *     tabulated_potential.Command(bonded_statistics,"hist",interactions);
+ *
+ * The above example creates the object it then proceeds to set one of the
+ * properties of the histogram. In this case the number of data points is
+ * specified with the keyword 'n', the 11 indicates we want the histogram to
+ * consist of 11 bins. To actually create the histogram the Command method is 
+ * called a second time but because the 'set' keyword is not the first element
+ * in the vector of strings the tabulated potential object assumes it is a file
+ * name were the histogram will be written. The following labels ("bond1",
+ * "bond2", etc...) specify the interactions to be sorted into the histogram. 
+ * Running this code should produce a file named file1.txt containing two 
+ * columns. 
+ *
+ * column1 = the bin edge, column2 = the contents of the histogram
+ *
+ * If the table potential is printed instead of the historgram of interactions
+ * than 3 columns are printed e.g. in the example below:
+ *
+ *     TabulatedPotential tabulated_potential;
+ *
+ *     map<string,AnalysisTool *> commands;
+ *     tabulated_potential.Register(commands);
+ *
+ *     vector<string> arguments{"set","T","275"};
+ *     vector<string> arguments2{"set","smooth_pot","1"};
+ *     vector<string> arguments3{"set","periodic","1"};
+ *
+ *     tabulated_potential.Command(bonded_statistics,"tab",arguments);
+ *     tabulated_potential.Command(bonded_statistics,"tab",arguments1);
+ *     tabulated_potential.Command(bonded_statistics,"tab",arguments2);
+ *
+ *     vector<string> interactions{"file2.txt","bond1","bond2","bond3",...};
+ *     tabulated_potential.Command(bonded_statistics,"tab",interactions);
+ *
+ * Here, notice we are using the 'tab' keyword to indicate it is for the 
+ * tabulated potential. We are also setting several properities. The temperature
+ * is changed from the default 300 Kelvin to 275 Kelvin. Smooth potential is set
+ * to 1 this has the affect of smoothing the potential after boltzmann inversion
+ * is done. If a value greater than 1 were used it would smooth the data several
+ * times upto the number specified. And the final setting was to make the 
+ * tabulated potential periodic. The value "1" is converted to a boolean which
+ * is interpreted as true. 
+ *
+ * Finally, the data is printed to a file called "file2.txt" which contains 
+ * three columns:
+ * 
+ * column1 = the bin edge, column2 = potential, column3 = the force
+ **/
 class TabulatedPotential
     : public AnalysisTool
 {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,20 +1,24 @@
 find_package(Boost 1.57.0 REQUIRED COMPONENTS unit_test_framework)
+
 foreach(PROG
   test_bead
   test_beadtriple
   test_basebead
   test_beadstructure
+  test_bondedstatistics
+  test_csg_topology
   test_interaction
   test_lammpsdatareader 
   test_lammpsdumpreaderwriter
   test_nblist_3body
   test_nblistgrid_3body
   test_pdbreader
+  test_tabulatedpotential
   test_triplelist )
 
   file(GLOB ${PROG}_SOURCES ${PROG}.cc)
   add_executable(unit_${PROG} ${${PROG}_SOURCES})
-  target_link_libraries(unit_${PROG} votca_csg ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  target_link_libraries(unit_${PROG} votca_csg_boltzmann votca_csg ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
   target_compile_definitions(unit_${PROG} PRIVATE BOOST_TEST_DYN_LINK)
   add_test(unit_${PROG} unit_${PROG})
   # run tests for csg (for coverage) as well

--- a/src/tests/test_bondedstatistics.cc
+++ b/src/tests/test_bondedstatistics.cc
@@ -46,12 +46,15 @@ BOOST_AUTO_TEST_CASE(test_bondedstatistics_constructor) {
 BOOST_AUTO_TEST_CASE(test_bondedstatistics_begin) {
   Topology top;                                                                  
   // Create two bonded interactions                                              
-  string interaction_group = "covalent_bond";         
-  string interaction_group_compare = ":covalent_bond";  
+  string interaction_group = "covalent_bond1";         
+  string interaction_group_compare = ":covalent_bond1";  
   auto bond1 = new IBond(0,1);                                                   
   bond1->setGroup(interaction_group);                                            
+
+  string interaction_group2 = "covalent_bond2";         
+  string interaction_group_compare2 = ":covalent_bond2";  
   auto bond2 = new IBond(1,2);                                                   
-  bond2->setGroup(interaction_group);                                            
+  bond2->setGroup(interaction_group2);                                            
 
   top.AddBondedInteraction(bond1);                                               
   top.AddBondedInteraction(bond2);                                               
@@ -63,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_bondedstatistics_begin) {
   vector<DataCollection<double>::array *>& vector_of_arrays = data_collection.Data(); 
   BOOST_CHECK_EQUAL(vector_of_arrays.size(),2);
   BOOST_CHECK_EQUAL(vector_of_arrays.at(0)->getName(),interaction_group_compare);
-  BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->getName(),interaction_group_compare);
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->getName(),interaction_group_compare2);
   // The arrays do not store any numbers at this point
   BOOST_CHECK_EQUAL(vector_of_arrays.at(0)->size(),0);
   BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->size(),0);
@@ -128,11 +131,12 @@ BOOST_AUTO_TEST_CASE(test_evalconfiguration_begin) {
     bead_ptr3->setPos(pos_bead3);
 
     // Create two bonded interactions                                              
-    string interaction_group = "covalent_bond";         
+    string interaction_group = "covalent_bond1";         
     auto bond1 = new IBond(0,1);                                                   
     bond1->setGroup(interaction_group);                                            
+    string interaction_group2 = "covalent_bond2";         
     auto bond2 = new IBond(1,2);                                                   
-    bond2->setGroup(interaction_group);                                            
+    bond2->setGroup(interaction_group2);                                            
 
     top.AddBondedInteraction(bond1);                                               
     top.AddBondedInteraction(bond2);                                               

--- a/src/tests/test_bondedstatistics.cc
+++ b/src/tests/test_bondedstatistics.cc
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_evalconfiguration_begin) {
     vec pos_bead3(5.0,6.0,5.0);
     auto bead_ptr3 = top.CreateBead(symmetry,                                      
         bead_name3,bead_type_ptr,residue_number,mass,charge);                      
-    bead_ptr2->setId(2);                                                           
+    bead_ptr3->setId(2);                                                           
     bead_ptr3->setPos(pos_bead3);
 
     // Create two bonded interactions                                              

--- a/src/tests/test_bondedstatistics.cc
+++ b/src/tests/test_bondedstatistics.cc
@@ -70,4 +70,89 @@ BOOST_AUTO_TEST_CASE(test_bondedstatistics_begin) {
   top.Cleanup(); 
 }
 
+BOOST_AUTO_TEST_CASE(test_evalconfiguration_begin) {
+  Topology top;     
+
+  // Setup topology class
+  { 
+    // Set the system size
+    double x1 = 10.0;                                                               
+    double y1 = 0.0;                                                               
+    double z1 = 0.0;                                                               
+
+    double x2 = 0.0;                                                               
+    double y2 = 10.0;                                                               
+    double z2 = 0.0;                                                               
+
+    double x3 = 0.0;                                                               
+    double y3 = 0.0;                                                               
+    double z3 = 10.0;                                                               
+
+    vec v1(x1,y1,z1);                                                              
+    vec v2(x2,y2,z2);                                                              
+    vec v3(x3,y3,z3);                                                              
+
+    matrix box(v1,v2,v3);         
+    top.setBox(box);
+
+    // Create three beads
+    byte_t symmetry = 1;                                                           
+
+    string bead_type_name = "type1";                                               
+    auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);                  
+
+    int residue_number = 1;                                                        
+    double mass = 1.1;                                                             
+    double charge = 0.3;                                                           
+
+    // Create 3 beads                                                              
+    string bead_name = "bead_test";                                                
+    vec pos_bead1(5.0,3.0,5.0);
+    auto bead_ptr = top.CreateBead(symmetry,                                       
+        bead_name,bead_type_ptr,residue_number,mass,charge);                       
+    bead_ptr->setId(0);                                                            
+    bead_ptr->setPos(pos_bead1);
+
+    string bead_name2 = "bead_test2";                                              
+    vec pos_bead2(5.0,4.0,5.0);
+    auto bead_ptr2 = top.CreateBead(symmetry,                                      
+        bead_name2,bead_type_ptr,residue_number,mass,charge);                      
+    bead_ptr2->setId(1);                                                           
+    bead_ptr2->setPos(pos_bead2);
+
+    string bead_name3 = "bead_test3";                                              
+    vec pos_bead3(5.0,6.0,5.0);
+    auto bead_ptr3 = top.CreateBead(symmetry,                                      
+        bead_name3,bead_type_ptr,residue_number,mass,charge);                      
+    bead_ptr2->setId(2);                                                           
+    bead_ptr3->setPos(pos_bead3);
+
+    // Create two bonded interactions                                              
+    string interaction_group = "covalent_bond";         
+    auto bond1 = new IBond(0,1);                                                   
+    bond1->setGroup(interaction_group);                                            
+    auto bond2 = new IBond(1,2);                                                   
+    bond2->setGroup(interaction_group);                                            
+
+    top.AddBondedInteraction(bond1);                                               
+    top.AddBondedInteraction(bond2);                                               
+  }
+
+  BondedStatistics bonded_statistics;
+  bonded_statistics.BeginCG(&top,nullptr);
+
+  // Calling EvalConfiguration on IBond structures will store the distances
+  // between the beads in the BondedStatitics class
+  bonded_statistics.EvalConfiguration(&top,nullptr);
+
+  DataCollection<double>& data_collection = bonded_statistics.BondedValues();
+  vector<DataCollection<double>::array *>& vector_of_arrays = data_collection.Data(); 
+  
+  // Distance between bead 0 and bead 1 
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(0)->at(0),1.0);
+  // Distance between bead 1 and bead 2
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->at(0),2.0);
+
+  top.Cleanup(); 
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_bondedstatistics.cc
+++ b/src/tests/test_bondedstatistics.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE bondedstatistics_test
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <map>
+#include <string>
+#include "../csg_boltzmann/bondedstatistics.h"
+
+using namespace std;
+using namespace votca::csg;
+using namespace votca::tools;
+
+// used for rounding doubles so we can compare them
+double round_(double v, int p) {
+  v *= pow(10, p);
+  v = round(v);
+  v /= pow(10, p);
+  return v;
+}
+
+BOOST_AUTO_TEST_SUITE(bondedstatistics_test)
+
+BOOST_AUTO_TEST_CASE(test_bondedstatistics_constructor) { 
+  BondedStatistics bonded_statistics; 
+}
+
+BOOST_AUTO_TEST_CASE(test_bondedstatistics_begin) {
+  Topology top;                                                                  
+  // Create two bonded interactions                                              
+  string interaction_group = "covalent_bond";         
+  string interaction_group_compare = ":covalent_bond";  
+  auto bond1 = new IBond(0,1);                                                   
+  bond1->setGroup(interaction_group);                                            
+  auto bond2 = new IBond(1,2);                                                   
+  bond2->setGroup(interaction_group);                                            
+
+  top.AddBondedInteraction(bond1);                                               
+  top.AddBondedInteraction(bond2);                                               
+
+  BondedStatistics bonded_statistics;
+  bonded_statistics.BeginCG(&top,nullptr);
+
+  DataCollection<double>& data_collection = bonded_statistics.BondedValues();
+  vector<DataCollection<double>::array *>& vector_of_arrays = data_collection.Data(); 
+  BOOST_CHECK_EQUAL(vector_of_arrays.size(),2);
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(0)->getName(),interaction_group_compare);
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->getName(),interaction_group_compare);
+  // The arrays do not store any numbers at this point
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(0)->size(),0);
+  BOOST_CHECK_EQUAL(vector_of_arrays.at(1)->size(),0);
+  top.Cleanup(); 
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_csg_topology.cc
+++ b/src/tests/test_csg_topology.cc
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE csg_topology_test
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+#include "../../include/votca/csg/topology.h"
+#include "../../include/votca/csg/beadtype.h"
+
+// used for rounding doubles so we can compare them                              
+double round_(double v, int p) {                                                 
+  v *= pow(10, p);                                                               
+  v = round(v);                                                                  
+  v /= pow(10, p);                                                               
+  return v;                                                                      
+}     
+
+using namespace std;
+using namespace votca::tools;
+using namespace votca::csg;
+
+BOOST_AUTO_TEST_SUITE(csg_topology_test)
+
+BOOST_AUTO_TEST_CASE(constructors_test) { Topology top; }
+
+BOOST_AUTO_TEST_CASE(box_test) { 
+
+  // Box takes a vector
+  double x1 = 2.0;
+  double y1 = 0.0;
+  double z1 = 0.0;
+
+  double x2 = 0.0;
+  double y2 = 2.0;
+  double z2 = 0.0;
+
+  double x3 = 0.0;
+  double y3 = 0.0;
+  double z3 = 2.0;
+
+  vec v1(x1,y1,z1);
+  vec v2(x2,y2,z2);
+  vec v3(x3,y3,z3);
+
+  matrix box(v1,v2,v3);
+
+  Topology top;
+  top.setBox(box);
+
+  auto vol = top.BoxVolume();
+  BOOST_CHECK_EQUAL(static_cast<int>(vol),8);
+  auto box2 = top.getBox();
+  
+  auto v1_2 = box2.getCol(0);
+  auto v2_2 = box2.getCol(1);
+  auto v3_2 = box2.getCol(2);
+  BOOST_CHECK_EQUAL(v1,v1_2);
+  BOOST_CHECK_EQUAL(v2,v2_2);
+  BOOST_CHECK_EQUAL(v3,v3_2);
+}
+
+BOOST_AUTO_TEST_CASE(simple_test){
+
+  Topology top;
+  top.setStep(1);
+  BOOST_CHECK_EQUAL(top.getStep(),1);
+  top.setTime(1.21);
+  BOOST_CHECK_EQUAL(static_cast<int>(top.getTime()*100),121);
+
+}
+
+BOOST_AUTO_TEST_CASE(create_bead_type){
+  Topology top;
+  string bead_type_name = "type1";
+  auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);
+
+  BOOST_CHECK(bead_type_ptr->getName()==bead_type_name);
+
+  top.Cleanup();
+}
+/**
+ * Test is creating a bead with the topology object and then ensuring that the
+ * bead has the correct properties.
+ **/
+BOOST_AUTO_TEST_CASE(create_bead) {
+  Topology top;
+  // 1 - for spherical bead
+  byte_t symmetry = 1;
+  string bead_name = "bead_test";
+
+  string bead_type_name = "type1";
+  auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);
+
+  int residue_number = 1;
+  double mass = 1.1;
+  double charge = 0.3;
+
+  auto bead_ptr = top.CreateBead(symmetry,
+      bead_name,bead_type_ptr,residue_number,mass,charge);
+
+  BOOST_CHECK_EQUAL(round_(bead_ptr->getQ()*10,1),3.0);
+  BOOST_CHECK_EQUAL(round_(bead_ptr->getMass()*10,2),11);
+  BOOST_CHECK_EQUAL(bead_ptr->getResnr(),residue_number);
+  BOOST_CHECK_EQUAL(bead_ptr->getSymmetry(),symmetry);
+  BOOST_CHECK(bead_ptr->getName() == bead_name);
+
+  auto bead_type_ptr2 = bead_ptr->getType();
+  BOOST_CHECK(bead_type_ptr2->getName() == bead_type_ptr->getName());
+  BOOST_CHECK_EQUAL(top.BeadCount(),1);
+
+  top.Cleanup();
+
+}
+
+/**
+ * This test ensures that the interactions are stored correctly. Three beads
+ * are created and two interactions are created connecting the three beads. The
+ * interactions are then checked to be sure they hold the right information.
+ **/
+BOOST_AUTO_TEST_CASE(add_bonded_interation_test){
+  Topology top;
+  // 1 - for spherical bead
+  byte_t symmetry = 1;
+
+  string bead_type_name = "type1";
+  auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);
+
+  int residue_number = 1;
+  double mass = 1.1;
+  double charge = 0.3;
+
+  // Create 3 beads
+  string bead_name = "bead_test";
+  auto bead_ptr = top.CreateBead(symmetry,
+      bead_name,bead_type_ptr,residue_number,mass,charge);
+  bead_ptr->setId(0);
+
+  string bead_name2 = "bead_test2";
+  auto bead_ptr2 = top.CreateBead(symmetry,
+      bead_name2,bead_type_ptr,residue_number,mass,charge);
+  bead_ptr2->setId(1);
+
+  string bead_name3 = "bead_test3";
+  auto bead_ptr3 = top.CreateBead(symmetry,
+      bead_name3,bead_type_ptr,residue_number,mass,charge);
+  bead_ptr2->setId(2);
+
+  BOOST_CHECK_EQUAL(top.BeadCount(),3);
+
+  // Create two bonded interactions
+  string interaction_group = "bond";
+  auto bond1 = new IBond(0,1);
+  bond1->setGroup(interaction_group);
+  auto bond2 = new IBond(1,2);
+  bond2->setGroup(interaction_group);
+
+  top.AddBondedInteraction(bond1);
+  top.AddBondedInteraction(bond2);
+
+  auto interaction_container = top.BondedInteractions();
+  BOOST_CHECK_EQUAL(interaction_container.size(),2);
+
+  cout << "interaction name " << interaction_container.at(0)->getName() << endl;
+  cout << "interaction name " << interaction_container.at(1)->getName() << endl;
+  BOOST_CHECK_EQUAL(interaction_container.at(0)->getBeadId(0),0);
+  BOOST_CHECK_EQUAL(interaction_container.at(0)->getBeadId(1),1);
+  BOOST_CHECK_EQUAL(interaction_container.at(1)->getBeadId(0),1);
+  BOOST_CHECK_EQUAL(interaction_container.at(1)->getBeadId(1),2);
+
+  top.Cleanup();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_csg_topology.cc
+++ b/src/tests/test_csg_topology.cc
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(add_bonded_interation_test){
   string bead_name3 = "bead_test3";
   auto bead_ptr3 = top.CreateBead(symmetry,
       bead_name3,bead_type_ptr,residue_number,mass,charge);
-  bead_ptr2->setId(2);
+  bead_ptr3->setId(2);
 
   BOOST_CHECK_EQUAL(top.BeadCount(),3);
 

--- a/src/tests/test_tabulatedpotential.cc
+++ b/src/tests/test_tabulatedpotential.cc
@@ -20,31 +20,32 @@
 #define BOOST_TEST_MODULE tabulatedpotential_test
 #include <boost/test/unit_test.hpp>
 
-#include <map>
-#include <cstdlib>
-#include <vector>
-#include <string>
 #include "../csg_boltzmann/tabulatedpotential.h"
+#include <cstdlib>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace std;
 using namespace votca::csg;
 using namespace votca::tools;
 
-double randomDouble(double min_val, double max_val){
-  double random_num = static_cast<double>(rand())/static_cast<double>(RAND_MAX);
-  return min_val+random_num*(max_val-min_val); 
+double randomDouble(double min_val, double max_val) {
+  double random_num =
+      static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+  return min_val + random_num * (max_val - min_val);
 }
 
-vector<double> getColumnFromFile(string file_name, int column){
+vector<double> getColumnFromFile(string file_name, int column) {
   vector<double> data;
   ifstream file;
   file.open(file_name);
   string line;
-  if(file.is_open()){
-    while( getline(file,line)){
+  if (file.is_open()) {
+    while (getline(file, line)) {
       string word;
       istringstream ss(line);
-      for(int i=0;i<column;++i){
+      for (int i = 0; i < column; ++i) {
         ss >> word;
       }
       data.push_back(stod(word));
@@ -64,75 +65,75 @@ double round_(double v, int p) {
 
 BOOST_AUTO_TEST_SUITE(tabulatedpotential_test)
 
-BOOST_AUTO_TEST_CASE(test_tabulatedpotential_constructor) { 
+BOOST_AUTO_TEST_CASE(test_tabulatedpotential_constructor) {
   TabulatedPotential tabulatedpotential;
-  BOOST_CHECK_EQUAL(tabulatedpotential.getTemperature(),300);
+  BOOST_CHECK_EQUAL(tabulatedpotential.getTemperature(), 300);
   auto iterations_to_smooth = tabulatedpotential.getSmoothIterations();
-  BOOST_CHECK_EQUAL(iterations_to_smooth.first,0);
-  BOOST_CHECK_EQUAL(iterations_to_smooth.second,0);
+  BOOST_CHECK_EQUAL(iterations_to_smooth.first, 0);
+  BOOST_CHECK_EQUAL(iterations_to_smooth.second, 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_register){
-  TabulatedPotential tablulatedpotential; 
-  map<string,AnalysisTool *> commands;
+BOOST_AUTO_TEST_CASE(test_register) {
+  TabulatedPotential tablulatedpotential;
+  map<string, AnalysisTool *> commands;
   tablulatedpotential.Register(commands);
 }
 
-BOOST_AUTO_TEST_CASE(test_command){
+BOOST_AUTO_TEST_CASE(test_command) {
 
   Topology top;
   BondedStatistics bonded_statistics;
-  string interaction_group = "interaction";                                  
+  string interaction_group = "interaction";
   string interaction_group_name = ":interaction";
   vector<string> interactions;
   interactions.push_back("file_interactions.txt");
   // Setup BondedStatistics Object
   {
 
-    // Set the system size                                                       
-    double x1 = 20.0;                                                            
-    double y1 = 0.0;                                                             
-    double z1 = 0.0;                                                             
+    // Set the system size
+    double x1 = 20.0;
+    double y1 = 0.0;
+    double z1 = 0.0;
 
-    double x2 = 0.0;                                                             
-    double y2 = 20.0;                                                            
-    double z2 = 0.0;                                                             
+    double x2 = 0.0;
+    double y2 = 20.0;
+    double z2 = 0.0;
 
-    double x3 = 0.0;                                                             
-    double y3 = 0.0;                                                             
-    double z3 = 20.0;                                                            
+    double x3 = 0.0;
+    double y3 = 0.0;
+    double z3 = 20.0;
 
-    vec v1(x1,y1,z1);                                                            
-    vec v2(x2,y2,z2);                                                            
-    vec v3(x3,y3,z3);                                                            
+    vec v1(x1, y1, z1);
+    vec v2(x2, y2, z2);
+    vec v3(x3, y3, z3);
 
-    matrix box(v1,v2,v3);                                                        
-    top.setBox(box);                                                             
+    matrix box(v1, v2, v3);
+    top.setBox(box);
 
-    // Create three beads                                                        
-    byte_t symmetry = 1;                                                         
+    // Create three beads
+    byte_t symmetry = 1;
 
-    string bead_type_name = "H2";                                             
-    auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);                
+    string bead_type_name = "H2";
+    auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);
 
-    double mass = 0.9;                                                           
-    double charge = 0.0;                                                         
+    double mass = 0.9;
+    double charge = 0.0;
 
     // Create a bunch of H2 molecules, each bead is considered a molecule they
-    // are placed on a regular grid so the table properties can be compared 
+    // are placed on a regular grid so the table properties can be compared
     // consistently
-    
+
     int number_of_H2 = 0;
     int residue_number = 0;
-    for(double x=2.0; x<(x1-2.0); x+=4.0){
-      for(double y=2.0; y<(y2-2.0); y+=3.0){
-        for(double z=2.0;z<(z3-2.0);z+=4.0){
+    for (double x = 2.0; x < (x1 - 2.0); x += 4.0) {
+      for (double y = 2.0; y < (y2 - 2.0); y += 3.0) {
+        for (double z = 2.0; z < (z3 - 2.0); z += 4.0) {
           residue_number++;
 
-          string bead_name =to_string(number_of_H2)+"_H2";
-          vec bead_pos(x,y,z);  
-          auto bead_ptr = top.CreateBead(symmetry,                                     
-              bead_name,bead_type_ptr,residue_number,mass,charge);
+          string bead_name = to_string(number_of_H2) + "_H2";
+          vec bead_pos(x, y, z);
+          auto bead_ptr = top.CreateBead(symmetry, bead_name, bead_type_ptr,
+                                         residue_number, mass, charge);
           bead_ptr->setId(number_of_H2);
           bead_ptr->setPos(bead_pos);
           number_of_H2++;
@@ -142,25 +143,28 @@ BOOST_AUTO_TEST_CASE(test_command){
 
     cout << "Number of H2 " << number_of_H2 << endl;
     // Every molecule interacts with every other molecule
-    for(int index=0; index<number_of_H2;++index){
-      for(int index2=index+1;index2<number_of_H2;++index2){
-        auto bond = new IBond(index,index2);                                                 
-        bond->setGroup(interaction_group+to_string(index)+"_"+to_string(index2));                                          
-        top.AddBondedInteraction(bond);                                             
-        interactions.push_back(interaction_group_name+to_string(index)+"_"+to_string(index2));
+    for (int index = 0; index < number_of_H2; ++index) {
+      for (int index2 = index + 1; index2 < number_of_H2; ++index2) {
+        auto bond = new IBond(index, index2);
+        bond->setGroup(interaction_group + to_string(index) + "_" +
+                       to_string(index2));
+        top.AddBondedInteraction(bond);
+        interactions.push_back(interaction_group_name + to_string(index) + "_" +
+                               to_string(index2));
       }
     }
 
-    bonded_statistics.BeginCG(&top,nullptr);
-    bonded_statistics.EvalConfiguration(&top,nullptr);
-  }// End of setup
+    bonded_statistics.BeginCG(&top, nullptr);
+    bonded_statistics.EvalConfiguration(&top, nullptr);
+  } // End of setup
 
-  DataCollection<double> & bonded_values = bonded_statistics.BondedValues();
-  cout << "bonded_values after pulling out of statistics " << bonded_values.size() << endl;
+  DataCollection<double> &bonded_values = bonded_statistics.BondedValues();
+  cout << "bonded_values after pulling out of statistics "
+       << bonded_values.size() << endl;
   size_t number_of_interactions = bonded_values.size();
 
-  TabulatedPotential tabulatedpotential; 
-  map<string,AnalysisTool *> commands;
+  TabulatedPotential tabulatedpotential;
+  map<string, AnalysisTool *> commands;
   tabulatedpotential.Register(commands);
 
   // Test 1
@@ -173,33 +177,32 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("5");
 
     string command = "tab";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
-    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0), 3);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 14.46);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),5.16);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),1.84);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.00);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.36);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),5.70);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 5.16);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 1.84);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 0.00);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 0.36);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 5.70);
 
-    BOOST_CHECK_EQUAL(round_(column3.at(0),2),1.16);
-    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.90);
-    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.26);
-    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-1.00);
-    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-1.87);
+    BOOST_CHECK_EQUAL(round_(column3.at(0), 2), 1.16);
+    BOOST_CHECK_EQUAL(round_(column3.at(1), 2), 0.90);
+    BOOST_CHECK_EQUAL(round_(column3.at(2), 2), 0.26);
+    BOOST_CHECK_EQUAL(round_(column3.at(3), 2), -1.00);
+    BOOST_CHECK_EQUAL(round_(column3.at(4), 2), -1.87);
 
   } // End of Test 1
-
 
   // Test 2
   {
@@ -210,33 +213,33 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","smooth_pdf","2"};
+    vector<string> arguments2{"set", "smooth_pdf", "2"};
     string command = "tab";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
-    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0), 3);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 14.46);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.79);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.24);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.00);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.14);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.77);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 0.79);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 0.24);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 0.00);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 0.14);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 0.77);
 
-    BOOST_CHECK_EQUAL(round_(column3.at(0),2),0.19);
-    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.14);
-    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.02);
-    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-0.13);
-    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-0.22);
+    BOOST_CHECK_EQUAL(round_(column3.at(0), 2), 0.19);
+    BOOST_CHECK_EQUAL(round_(column3.at(1), 2), 0.14);
+    BOOST_CHECK_EQUAL(round_(column3.at(2), 2), 0.02);
+    BOOST_CHECK_EQUAL(round_(column3.at(3), 2), -0.13);
+    BOOST_CHECK_EQUAL(round_(column3.at(4), 2), -0.22);
 
   } // End of Test 2
 
@@ -249,35 +252,35 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","smooth_pdf","2"};
-    vector<string> arguments3{"set","smooth_pot","1"};
+    vector<string> arguments2{"set", "smooth_pdf", "2"};
+    vector<string> arguments3{"set", "smooth_pot", "1"};
     string command = "tab";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,arguments3);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, arguments3);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
-    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0), 3);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 14.46);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.58);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.36);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.26);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.33);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.59);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 0.58);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 0.36);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 0.26);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 0.33);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 0.59);
 
-    BOOST_CHECK_EQUAL(round_(column3.at(0),2),0.08);
-    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.06);
-    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.01);
-    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-0.06);
-    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-0.09);
+    BOOST_CHECK_EQUAL(round_(column3.at(0), 2), 0.08);
+    BOOST_CHECK_EQUAL(round_(column3.at(1), 2), 0.06);
+    BOOST_CHECK_EQUAL(round_(column3.at(2), 2), 0.01);
+    BOOST_CHECK_EQUAL(round_(column3.at(3), 2), -0.06);
+    BOOST_CHECK_EQUAL(round_(column3.at(4), 2), -0.09);
 
   } // End of Test 3
 
@@ -290,26 +293,26 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","periodic","1"};
+    vector<string> arguments2{"set", "periodic", "1"};
     string command = "hist";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 14.46);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.03);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.06);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.12);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.11);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.03);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 0.03);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 0.06);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 0.12);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 0.11);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 0.03);
 
   } // End of Test 4
 
@@ -322,28 +325,28 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","periodic","1"};
-    vector<string> arguments3{"set","normalize","0"};
+    vector<string> arguments2{"set", "periodic", "1"};
+    vector<string> arguments3{"set", "normalize", "0"};
     string command = "hist";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,arguments3);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, arguments3);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 14.46);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),404.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),848.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),1772.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),1536.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),404.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 404.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 848.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 1772.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 1536.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 404.0);
 
   } // End of Test 5
 
@@ -356,30 +359,30 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","periodic","1"};
-    vector<string> arguments3{"set","extend","0"};
-    vector<string> arguments4{"set","auto","0"};
+    vector<string> arguments2{"set", "periodic", "1"};
+    vector<string> arguments3{"set", "extend", "0"};
+    vector<string> arguments4{"set", "auto", "0"};
     string command = "hist";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,arguments3);
-    tabulatedpotential.Command(bonded_statistics,command,arguments4);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, arguments3);
+    tabulatedpotential.Command(bonded_statistics, command, arguments4);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 1.00);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),1508.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),1164.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),436.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),1452.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),1508.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 1508.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 1164.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 436.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 1452.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 1508.0);
 
   } // End of Test 6
 
@@ -392,26 +395,26 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","scale","bond"};
+    vector<string> arguments2{"set", "scale", "bond"};
     string command = "hist";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 1.00);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),19372.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),18624.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),1744.0);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),2581.33);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),19372.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 19372.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 18624.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 1744.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 2581.33);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 19372.0);
 
   } // End of Test 7
 
@@ -424,29 +427,28 @@ BOOST_AUTO_TEST_CASE(test_command){
     arguments.push_back("n");
     arguments.push_back("5");
 
-    vector<string> arguments2{"set","scale","angle"};
+    vector<string> arguments2{"set", "scale", "angle"};
     string command = "hist";
-    tabulatedpotential.Command(bonded_statistics,command,arguments);
-    tabulatedpotential.Command(bonded_statistics,command,arguments2);
-    tabulatedpotential.Command(bonded_statistics,command,interactions);
+    tabulatedpotential.Command(bonded_statistics, command, arguments);
+    tabulatedpotential.Command(bonded_statistics, command, arguments2);
+    tabulatedpotential.Command(bonded_statistics, command, interactions);
 
-    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
-    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column1 = getColumnFromFile(interactions.at(0), 1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0), 2);
 
-    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
-    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
-    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
-    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
-    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(0), 2), 0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1), 2), 0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2), 2), 0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3), 2), 0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4), 2), 1.00);
 
-    BOOST_CHECK_EQUAL(round_(column2.at(0),2),5593.78);
-    BOOST_CHECK_EQUAL(round_(column2.at(1),2),4704.86);
-    BOOST_CHECK_EQUAL(round_(column2.at(2),2),909.42);
-    BOOST_CHECK_EQUAL(round_(column2.at(3),2),2130.16);
-    BOOST_CHECK_EQUAL(round_(column2.at(4),2),5593.78);
+    BOOST_CHECK_EQUAL(round_(column2.at(0), 2), 5593.78);
+    BOOST_CHECK_EQUAL(round_(column2.at(1), 2), 4704.86);
+    BOOST_CHECK_EQUAL(round_(column2.at(2), 2), 909.42);
+    BOOST_CHECK_EQUAL(round_(column2.at(3), 2), 2130.16);
+    BOOST_CHECK_EQUAL(round_(column2.at(4), 2), 5593.78);
 
   } // End of Test 8
-
 
   top.Cleanup();
 }

--- a/src/tests/test_tabulatedpotential.cc
+++ b/src/tests/test_tabulatedpotential.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE tabulatedpotential_test
+#include <boost/test/unit_test.hpp>
+
+#include <map>
+#include <cstdlib>
+#include <vector>
+#include <string>
+#include "../csg_boltzmann/tabulatedpotential.h"
+
+using namespace std;
+using namespace votca::csg;
+using namespace votca::tools;
+
+double randomDouble(double min_val, double max_val){
+  double f = static_cast<double>(rand())/static_cast<double>(RAND_MAX);
+  return min_val+f*(max_val-min_val); 
+}
+
+
+// used for rounding doubles so we can compare them
+double round_(double v, int p) {
+  v *= pow(10, p);
+  v = round(v);
+  v /= pow(10, p);
+  return v;
+}
+
+BOOST_AUTO_TEST_SUITE(tabulatedpotential_test)
+
+BOOST_AUTO_TEST_CASE(test_tabulatedpotential_constructor) { 
+  TabulatedPotential tablulatedpotential; 
+}
+
+BOOST_AUTO_TEST_CASE(test_register){
+  TabulatedPotential tablulatedpotential; 
+  map<string,AnalysisTool *> commands;
+  tablulatedpotential.Register(commands);
+}
+
+BOOST_AUTO_TEST_CASE(test_command){
+
+  Topology top;
+  BondedStatistics bonded_statistics;
+  // Setup BondedStatistics Object
+  {
+
+    // Set the system size                                                       
+    double x1 = 20.0;                                                            
+    double y1 = 0.0;                                                             
+    double z1 = 0.0;                                                             
+
+    double x2 = 0.0;                                                             
+    double y2 = 20.0;                                                            
+    double z2 = 0.0;                                                             
+
+    double x3 = 0.0;                                                             
+    double y3 = 0.0;                                                             
+    double z3 = 20.0;                                                            
+
+    vec v1(x1,y1,z1);                                                            
+    vec v2(x2,y2,z2);                                                            
+    vec v3(x3,y3,z3);                                                            
+
+    matrix box(v1,v2,v3);                                                        
+    top.setBox(box);                                                             
+
+    // Create three beads                                                        
+    byte_t symmetry = 1;                                                         
+
+    string bead_type_name = "H2";                                             
+    auto bead_type_ptr = top.GetOrCreateBeadType(bead_type_name);                
+
+    double mass = 0.9;                                                           
+    double charge = 0.0;                                                         
+
+    // Create a bunch of H2 molecules where the distance between them is 1.2
+    string interaction_group = "covalent_bond";                                  
+    double bond_length = 1.2;
+    int number_of_H2 = 10;
+    for(int index=0; index<number_of_H2;++index){
+      int residue_number = index+1;
+
+      string bead_name = to_string(index*2)+"H";     
+      double x = randomDouble(0.0,x1-bond_length*2);
+      double y = randomDouble(0.0,y2-bond_length*2);
+      double z = randomDouble(0.0,z3-bond_length*2);
+      vec bead_pos(x,y,z);  
+      auto bead_ptr = top.CreateBead(symmetry,                                     
+          bead_name,bead_type_ptr,residue_number,mass,charge);
+      bead_ptr->setId(index*2);
+      bead_ptr->setPos(bead_pos);
+
+      string bead_name2 = to_string(index*2+1)+"H";     
+      x += bond_length*(0.5+randomDouble(0.0,1.0));
+      y += bond_length*(0.5+randomDouble(0.0,1.0));
+      z += bond_length*(0.5+randomDouble(0.0,1.0));
+      vec bead_pos2(x,y,z);  
+      bead_ptr = top.CreateBead(symmetry,                                     
+          bead_name2,bead_type_ptr,residue_number,mass,charge);
+      bead_ptr->setId(index*2+1);
+      bead_ptr->setPos(bead_pos2);
+
+      auto bond = new IBond(index*2,index*2+1);                                                 
+      bond->setGroup(interaction_group);                                          
+      top.AddBondedInteraction(bond);                                             
+       
+    }
+    bonded_statistics.BeginCG(&top,nullptr);
+    bonded_statistics.EvalConfiguration(&top,nullptr);
+  }
+
+  TabulatedPotential tabulatedpotential; 
+  map<string,AnalysisTool *> commands;
+  tabulatedpotential.Register(commands);
+
+  vector<string> arguments;
+  arguments.push_back("set");
+  arguments.push_back("smooth_pdf");
+  arguments.push_back("2");
+
+  string command = "hist";
+  tabulatedpotential.Command(bonded_statistics,command,arguments);
+  top.Cleanup();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_tabulatedpotential.cc
+++ b/src/tests/test_tabulatedpotential.cc
@@ -161,7 +161,6 @@ BOOST_AUTO_TEST_CASE(test_command) {
   DataCollection<double> &bonded_values = bonded_statistics.BondedValues();
   cout << "bonded_values after pulling out of statistics "
        << bonded_values.size() << endl;
-  size_t number_of_interactions = bonded_values.size();
 
   TabulatedPotential tabulatedpotential;
   map<string, AnalysisTool *> commands;

--- a/src/tests/test_tabulatedpotential.cc
+++ b/src/tests/test_tabulatedpotential.cc
@@ -31,10 +31,28 @@ using namespace votca::csg;
 using namespace votca::tools;
 
 double randomDouble(double min_val, double max_val){
-  double f = static_cast<double>(rand())/static_cast<double>(RAND_MAX);
-  return min_val+f*(max_val-min_val); 
+  double random_num = static_cast<double>(rand())/static_cast<double>(RAND_MAX);
+  return min_val+random_num*(max_val-min_val); 
 }
 
+vector<double> getColumnFromFile(string file_name, int column){
+  vector<double> data;
+  ifstream file;
+  file.open(file_name);
+  string line;
+  if(file.is_open()){
+    while( getline(file,line)){
+      string word;
+      istringstream ss(line);
+      for(int i=0;i<column;++i){
+        ss >> word;
+      }
+      data.push_back(stod(word));
+    }
+    file.close();
+  }
+  return data;
+}
 
 // used for rounding doubles so we can compare them
 double round_(double v, int p) {
@@ -47,7 +65,11 @@ double round_(double v, int p) {
 BOOST_AUTO_TEST_SUITE(tabulatedpotential_test)
 
 BOOST_AUTO_TEST_CASE(test_tabulatedpotential_constructor) { 
-  TabulatedPotential tablulatedpotential; 
+  TabulatedPotential tabulatedpotential;
+  BOOST_CHECK_EQUAL(tabulatedpotential.getTemperature(),300);
+  auto iterations_to_smooth = tabulatedpotential.getSmoothIterations();
+  BOOST_CHECK_EQUAL(iterations_to_smooth.first,0);
+  BOOST_CHECK_EQUAL(iterations_to_smooth.second,0);
 }
 
 BOOST_AUTO_TEST_CASE(test_register){
@@ -60,6 +82,10 @@ BOOST_AUTO_TEST_CASE(test_command){
 
   Topology top;
   BondedStatistics bonded_statistics;
+  string interaction_group = "interaction";                                  
+  string interaction_group_name = ":interaction";
+  vector<string> interactions;
+  interactions.push_back("file_interactions.txt");
   // Setup BondedStatistics Object
   {
 
@@ -92,53 +118,336 @@ BOOST_AUTO_TEST_CASE(test_command){
     double mass = 0.9;                                                           
     double charge = 0.0;                                                         
 
-    // Create a bunch of H2 molecules where the distance between them is 1.2
-    string interaction_group = "covalent_bond";                                  
-    double bond_length = 1.2;
-    int number_of_H2 = 10;
-    for(int index=0; index<number_of_H2;++index){
-      int residue_number = index+1;
+    // Create a bunch of H2 molecules, each bead is considered a molecule they
+    // are placed on a regular grid so the table properties can be compared 
+    // consistently
+    
+    int number_of_H2 = 0;
+    int residue_number = 0;
+    for(double x=2.0; x<(x1-2.0); x+=4.0){
+      for(double y=2.0; y<(y2-2.0); y+=3.0){
+        for(double z=2.0;z<(z3-2.0);z+=4.0){
+          residue_number++;
 
-      string bead_name = to_string(index*2)+"H";     
-      double x = randomDouble(0.0,x1-bond_length*2);
-      double y = randomDouble(0.0,y2-bond_length*2);
-      double z = randomDouble(0.0,z3-bond_length*2);
-      vec bead_pos(x,y,z);  
-      auto bead_ptr = top.CreateBead(symmetry,                                     
-          bead_name,bead_type_ptr,residue_number,mass,charge);
-      bead_ptr->setId(index*2);
-      bead_ptr->setPos(bead_pos);
-
-      string bead_name2 = to_string(index*2+1)+"H";     
-      x += bond_length*(0.5+randomDouble(0.0,1.0));
-      y += bond_length*(0.5+randomDouble(0.0,1.0));
-      z += bond_length*(0.5+randomDouble(0.0,1.0));
-      vec bead_pos2(x,y,z);  
-      bead_ptr = top.CreateBead(symmetry,                                     
-          bead_name2,bead_type_ptr,residue_number,mass,charge);
-      bead_ptr->setId(index*2+1);
-      bead_ptr->setPos(bead_pos2);
-
-      auto bond = new IBond(index*2,index*2+1);                                                 
-      bond->setGroup(interaction_group);                                          
-      top.AddBondedInteraction(bond);                                             
-       
+          string bead_name =to_string(number_of_H2)+"_H2";
+          vec bead_pos(x,y,z);  
+          auto bead_ptr = top.CreateBead(symmetry,                                     
+              bead_name,bead_type_ptr,residue_number,mass,charge);
+          bead_ptr->setId(number_of_H2);
+          bead_ptr->setPos(bead_pos);
+          number_of_H2++;
+        }
+      }
     }
+
+    cout << "Number of H2 " << number_of_H2 << endl;
+    // Every molecule interacts with every other molecule
+    for(int index=0; index<number_of_H2;++index){
+      for(int index2=index+1;index2<number_of_H2;++index2){
+        auto bond = new IBond(index,index2);                                                 
+        bond->setGroup(interaction_group+to_string(index)+"_"+to_string(index2));                                          
+        top.AddBondedInteraction(bond);                                             
+        interactions.push_back(interaction_group_name+to_string(index)+"_"+to_string(index2));
+      }
+    }
+
     bonded_statistics.BeginCG(&top,nullptr);
     bonded_statistics.EvalConfiguration(&top,nullptr);
-  }
+  }// End of setup
+
+  DataCollection<double> & bonded_values = bonded_statistics.BondedValues();
+  cout << "bonded_values after pulling out of statistics " << bonded_values.size() << endl;
+  size_t number_of_interactions = bonded_values.size();
 
   TabulatedPotential tabulatedpotential; 
   map<string,AnalysisTool *> commands;
   tabulatedpotential.Register(commands);
 
-  vector<string> arguments;
-  arguments.push_back("set");
-  arguments.push_back("smooth_pdf");
-  arguments.push_back("2");
+  // Test 1
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
 
-  string command = "hist";
-  tabulatedpotential.Command(bonded_statistics,command,arguments);
+    string command = "tab";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),5.16);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),1.84);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.00);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.36);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),5.70);
+
+    BOOST_CHECK_EQUAL(round_(column3.at(0),2),1.16);
+    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.90);
+    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.26);
+    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-1.00);
+    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-1.87);
+
+  } // End of Test 1
+
+
+  // Test 2
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","smooth_pdf","2"};
+    string command = "tab";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.79);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.24);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.00);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.14);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.77);
+
+    BOOST_CHECK_EQUAL(round_(column3.at(0),2),0.19);
+    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.14);
+    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.02);
+    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-0.13);
+    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-0.22);
+
+  } // End of Test 2
+
+  // Test 3
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","smooth_pdf","2"};
+    vector<string> arguments3{"set","smooth_pot","1"};
+    string command = "tab";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,arguments3);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+    vector<double> column3 = getColumnFromFile(interactions.at(0),3);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.58);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.36);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.26);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.33);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.59);
+
+    BOOST_CHECK_EQUAL(round_(column3.at(0),2),0.08);
+    BOOST_CHECK_EQUAL(round_(column3.at(1),2),0.06);
+    BOOST_CHECK_EQUAL(round_(column3.at(2),2),0.01);
+    BOOST_CHECK_EQUAL(round_(column3.at(3),2),-0.06);
+    BOOST_CHECK_EQUAL(round_(column3.at(4),2),-0.09);
+
+  } // End of Test 3
+
+  // Test 4
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","periodic","1"};
+    string command = "hist";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),0.03);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),0.06);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),0.12);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),0.11);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),0.03);
+
+  } // End of Test 4
+
+  // Test 5
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","periodic","1"};
+    vector<string> arguments3{"set","normalize","0"};
+    string command = "hist";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,arguments3);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),3.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),5.86);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),8.73);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),11.59);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),14.46);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),404.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),848.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),1772.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),1536.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),404.0);
+
+  } // End of Test 5
+
+  // Test 6
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","periodic","1"};
+    vector<string> arguments3{"set","extend","0"};
+    vector<string> arguments4{"set","auto","0"};
+    string command = "hist";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,arguments3);
+    tabulatedpotential.Command(bonded_statistics,command,arguments4);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),1508.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),1164.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),436.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),1452.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),1508.0);
+
+  } // End of Test 6
+
+  // Test 7
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","scale","bond"};
+    string command = "hist";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),19372.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),18624.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),1744.0);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),2581.33);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),19372.0);
+
+  } // End of Test 7
+
+  // Test 8
+  {
+    vector<string> arguments;
+    // Set the table properties so that only 11 points are used, this way we do
+    // not need to compare as many
+    arguments.push_back("set");
+    arguments.push_back("n");
+    arguments.push_back("5");
+
+    vector<string> arguments2{"set","scale","angle"};
+    string command = "hist";
+    tabulatedpotential.Command(bonded_statistics,command,arguments);
+    tabulatedpotential.Command(bonded_statistics,command,arguments2);
+    tabulatedpotential.Command(bonded_statistics,command,interactions);
+
+    vector<double> column1 = getColumnFromFile(interactions.at(0),1);
+    vector<double> column2 = getColumnFromFile(interactions.at(0),2);
+
+    BOOST_CHECK_EQUAL(round_(column1.at(0),2),0.00);
+    BOOST_CHECK_EQUAL(round_(column1.at(1),2),0.25);
+    BOOST_CHECK_EQUAL(round_(column1.at(2),2),0.50);
+    BOOST_CHECK_EQUAL(round_(column1.at(3),2),0.75);
+    BOOST_CHECK_EQUAL(round_(column1.at(4),2),1.00);
+
+    BOOST_CHECK_EQUAL(round_(column2.at(0),2),5593.78);
+    BOOST_CHECK_EQUAL(round_(column2.at(1),2),4704.86);
+    BOOST_CHECK_EQUAL(round_(column2.at(2),2),909.42);
+    BOOST_CHECK_EQUAL(round_(column2.at(3),2),2130.16);
+    BOOST_CHECK_EQUAL(round_(column2.at(4),2),5593.78);
+
+  } // End of Test 8
+
+
   top.Cleanup();
 }
 


### PR DESCRIPTION
In an attempt to remove use of histogram and replace it with histogramnew without breaking the code it was necessary to setup a few unit tests for classes that made use of the histogram class. This merge is responsible for creating these tests which are located in the csg-boltzmann folder. 
In response to issue https://github.com/votca/tools/issues/47