### PR TITLE
cmake: fix underlinking of libvotca_csg_boltzmann

### DIFF
--- a/src/csg_boltzmann/CMakeLists.txt
+++ b/src/csg_boltzmann/CMakeLists.txt
@@ -16,3 +16,4 @@ endif(TXT2TAGS_FOUND AND BASH)
 
 list(REMOVE_ITEM CSG_BO_SOURCES "main.cc")
 add_library(votca_csg_boltzmann ${CSG_BO_SOURCES})
+target_link_libraries(votca_csg_boltzmann votca_csg)


### PR DESCRIPTION
Found under openSUSE, can be triggered by compliing with:
CMAKE_SHARED_LINKER_FLAGS='-Wl,--as-needed -Wl,--no-undefined -Wl,-z,now'