### PR TITLE
Stable fix beadtype segfault

### DIFF
--- a/include/votca/csg/basebead.h
+++ b/include/votca/csg/basebead.h
@@ -18,6 +18,10 @@
 #ifndef _VOTCA_CSG_BASEBEAD_H
 #define _VOTCA_CSG_BASEBEAD_H
 
+#include <memory>
+
+#include <boost/optional.hpp>
+
 #include <votca/csg/topologyitem.h>
 #include <votca/csg/moleculeitem.h>
 
@@ -53,19 +57,31 @@ public:
    * get the bead type
    * \return const bead type pointer
    */
-  virtual const BeadType *getType() const { return _type; }
+  virtual const std::weak_ptr<BeadType> getType() const {
+  //  return _type; 
+    if(_type){
+      return *_type; 
+    }
+    throw std::runtime_error("Cannot return beadtype has not been initialized.");
+
+  }
 
   /**
    * set the bead type
    * \param bead type object
    */
-  virtual void setType(BeadType *type) { _type = type; }
+  virtual void setType(std::weak_ptr<BeadType> type) { _type = type; }
 
   /**
    * get the bead type
    * \return - non constant bead type pointer
    */
-  virtual BeadType *Type() const { return _type; }
+  virtual std::weak_ptr<BeadType> Type() const { 
+    if(_type){
+      return *_type; 
+    }
+    throw std::runtime_error("Cannot return beadtype has not been initialized.");
+  }
 
   /**
    * get the mass of the base bead
@@ -108,11 +124,11 @@ public:
 
 protected:
   BaseBead()
-      : TopologyItem(nullptr), MoleculeItem(nullptr), _type(nullptr), 
+      : TopologyItem(nullptr), MoleculeItem(nullptr), 
       _mass(0.0), _bPos(false){};
 
 
-  BeadType *_type;
+  boost::optional<std::weak_ptr<BeadType>> _type;
 
   double _mass;
   vec _pos;

--- a/include/votca/csg/bead.h
+++ b/include/votca/csg/bead.h
@@ -339,7 +339,7 @@ protected:
   bool _bF;
 
   /// constructur
-  Bead(Topology *owner, int id, BeadType *type, byte_t symmetry, string name,
+  Bead(Topology *owner, int id, std::weak_ptr<BeadType> type, byte_t symmetry, string name,
        int resnr, double m, double q)
       : _symmetry(symmetry), _q(q), _resnr(resnr) {
     _parent = owner;

--- a/include/votca/csg/topology.h
+++ b/include/votca/csg/topology.h
@@ -44,7 +44,7 @@ class ExclusionList;
 
 typedef vector<Molecule *> MoleculeContainer;
 typedef vector<Bead *> BeadContainer;
-typedef vector<BeadType> BeadTypeContainer;
+typedef vector<shared_ptr<BeadType>> BeadTypeContainer;
 typedef vector<Residue *> ResidueContainer;
 typedef vector<Interaction *> InteractionContainer;
 
@@ -85,7 +85,7 @@ public:
      *
      * The function creates a new bead and adds it to the list of beads.     
      */
-    virtual Bead *CreateBead(byte_t symmetry, string name, BeadType *type, int resnr, double m, double q);
+    virtual Bead *CreateBead(byte_t symmetry, string name, std::weak_ptr<BeadType> type, int resnr, double m, double q);
 
      /**
      * \brief get bead type or create it
@@ -94,7 +94,7 @@ public:
      *
      * Returns an existing bead type or creates one if it doesn't exist yet
      */
-    virtual BeadType * GetOrCreateBeadType(string name);
+    virtual std::weak_ptr<BeadType> GetOrCreateBeadType(string name);
 
     /**
      * \brief creates a new molecule
@@ -193,7 +193,7 @@ public:
     void AddBondedInteraction(Interaction *ic);
     std::list<Interaction *> InteractionsInGroup(const string &group);
     
-    BeadType * getBeadType(const int i) { return &(_beadtypes[i]); }
+    std::weak_ptr<BeadType> getBeadType(const int i) { return (_beadtypes[i]); }
     Bead *getBead(const int i) const { return _beads[i]; }
     Residue *getResidue(const int i) const { return _residues[i]; }
     Molecule *getMolecule(const int i) const { return _molecules[i]; }
@@ -410,7 +410,7 @@ protected:
     string _particle_group;
 };
 
-inline Bead *Topology::CreateBead(byte_t symmetry, string name, BeadType *type, int resnr, double m, double q)
+inline Bead *Topology::CreateBead(byte_t symmetry, string name, std::weak_ptr<BeadType> type, int resnr, double m, double q)
 {
     
     Bead *b = new Bead(this, _beads.size(), type, symmetry, name, resnr, m, q);    

--- a/src/libcsg/beadlist.cc
+++ b/src/libcsg/beadlist.cc
@@ -37,15 +37,20 @@ int BeadList::Generate(Topology &top, const string &select)
     }
     
     for(iter=top.Beads().begin(); iter!=top.Beads().end();++iter) {
-        if (!selectByName){
-            if(wildcmp(pSelect.c_str(), (*iter)->getType()->getName().c_str())) {
-                push_back(*iter);
-            }
+      if (!selectByName){
+        auto weak_type = (*iter)->getType();
+        if(auto type = weak_type.lock()){
+          if(wildcmp(pSelect.c_str(), type->getName().c_str())) {
+            push_back(*iter);
+          }
         }else{
-            if(wildcmp(pSelect.c_str(), (*iter)->getName().c_str())) {
-                push_back(*iter);
-            }
+          throw runtime_error("Error cannot access beadtype in BeadList generate.");
         }
+      }else{
+        if(wildcmp(pSelect.c_str(), (*iter)->getName().c_str())) {
+          push_back(*iter);
+        }
+      }
     }
     return size();
 }
@@ -69,9 +74,14 @@ int BeadList::GenerateInSphericalSubvolume(Topology &top, const string &select, 
     for(iter=top.Beads().begin(); iter!=top.Beads().end();++iter) {
         if (abs(_topology->BCShortestConnection(ref, (*iter)->getPos())) > radius) continue;
         if (!selectByName){
-            if(wildcmp(pSelect.c_str(), (*iter)->getType()->getName().c_str())) {
-                push_back(*iter);
+          auto weak_type = (*iter)->getType();
+          if(auto type = weak_type.lock()){
+            if(wildcmp(pSelect.c_str(), type->getName().c_str())) {
+              push_back(*iter);
             }
+          }else{
+            throw runtime_error("Error beadtype is inaccessible in BeadList GenerateInSphericalSubvolume");
+          }
         }else{
             if(wildcmp(pSelect.c_str(), (*iter)->getName().c_str())) {
                 push_back(*iter);

--- a/src/libcsg/modules/io/dlpolytopologyreader.cc
+++ b/src/libcsg/modules/io/dlpolytopologyreader.cc
@@ -290,10 +290,15 @@ bool DLPOLYTopologyReader::ReadTopology(string file, Topology &top)
           Molecule *mi_replica = top.CreateMolecule(mol_name);
 	  for(int i=0;i<mi->BeadCount();i++){
 	    Bead *bead=mi->getBead(i);
-	    auto type = top.GetOrCreateBeadType(bead->Type()->getName());
 	    string beadname=mi->getBeadName(i);
-	    Bead *bead_replica = top.CreateBead(1, bead->getName(), type, res->getId(), bead->getMass(), bead->getQ());
-	    mi_replica->AddBead(bead_replica,beadname);
+	    auto weak_type = bead->Type();
+      Bead *bead_replica;
+      if(auto type = weak_type.lock()){
+        bead_replica = top.CreateBead(1, bead->getName(), type, res->getId(), bead->getMass(), bead->getQ());
+      }else{
+        throw runtime_error("Error in dlpolytopologyreader.cc in trying to getbead type it does not exist.");
+      }
+      mi_replica->AddBead(bead_replica,beadname);
 	  }
 	  matoms+=mi->BeadCount();
 	  InteractionContainer ics=mi->Interactions();

--- a/src/libcsg/modules/io/dlpolytrajectorywriter.cc
+++ b/src/libcsg/modules/io/dlpolytrajectorywriter.cc
@@ -116,12 +116,20 @@ void DLPOLYTrajectoryWriter::Write(Topology *conf)
       // AB: DL_POLY needs bead TYPE, not name!
 
       if( _isConfig) {
-
-	_fl << setw(8) << left << bead->getType()->getName() << right << setw(10) << i+1 << endl;
-
+        auto weak_type = bead->getType();
+        if(auto type = weak_type.lock()){ 
+	_fl << setw(8) << left << type->getName() << right << setw(10) << i+1 << endl;
+        }else{
+          throw runtime_error("DLPOLYTrajectoryWriter error with accessing beadtype.");
+        }
       } else {
 
-	_fl << setw(8) << left << bead->getType()->getName() << right << setw(10) << i+1;
+        auto weak_type = bead->getType();
+        if(auto type = weak_type.lock()){ 
+          _fl << setw(8) << left << type->getName() << right << setw(10) << i+1;
+        }else{
+          throw runtime_error("DLPOLYTrajectoryWriter error with accessing beadtype.");
+        }
 	_fl << setprecision(6) << setw(12) << bead->getMass() << setw(12) << bead->getQ() << setw(12) << "   0.0" << endl;
 
       }

--- a/src/libcsg/modules/io/lammpsdumpwriter.cc
+++ b/src/libcsg/modules/io/lammpsdumpwriter.cc
@@ -53,7 +53,12 @@ void LAMMPSDumpWriter::Write(Topology *conf)
 
     for(BeadContainer::iterator iter=conf->Beads().begin(); iter!=conf->Beads().end(); ++iter) {
         Bead *bi = *iter;
-        fprintf(_out,"%i %i", bi->getId()+1, bi->getType()->getId());
+        auto weak_type = bi->getType();
+        if(auto type = weak_type.lock()){
+          fprintf(_out,"%i %i", bi->getId()+1, type->getId());
+        }else{
+          throw runtime_error("Error in lammps dump writer cannot access beadtype.");
+        }
         fprintf(_out," %f %f %f",bi->getPos().getX(), bi->getPos().getY(), bi->getPos().getZ());
         if(v) {
             fprintf(_out, " %f %f %f", bi->getVel().getX(), bi->getVel().getY(), bi->getVel().getZ());

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -142,4 +142,15 @@ if(ENABLE_TESTING)
   add_test(NAME Compare_csg_resample_cubicfit_output COMMAND ${VOTCA_COMPARE} --etol ${REGRESSIONTEST_TOLERANCE} -f1 table_cubicfit -f2 ${REFPATH}/table_cubicfit WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(Compare_csg_resample_cubicfit_output PROPERTIES DEPENDS Run_csg_resample_cubicfit)
   set_tests_properties(Compare_csg_resample_cubicfit_output PROPERTIES LABELS "csg;tools;votca")
+  
+  set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_dump)
+  set(REFPATH ${CMAKE_CURRENT_SOURCE_DIR}/references/methanol-water/)
+  file(MAKE_DIRECTORY ${RUNPATH})
+  add_test(NAME Run_csg_dump
+    COMMAND ${BASH} -c "$<TARGET_FILE:csg_dump> --top ${REFPATH}/topol_cg.xml > csg_dump.out"
+    WORKING_DIRECTORY ${RUNPATH})
+  set_tests_properties(Run_csg_dump PROPERTIES LABELS "csg;tools;votca")
+  add_test(NAME Compare_csg_dump_output COMMAND ${CMAKE_COMMAND} -E compare_files csg_dump.out ${REFPATH}/csg_dump.out WORKING_DIRECTORY ${RUNPATH})
+  set_tests_properties(Compare_csg_dump_output PROPERTIES DEPENDS Run_csg_dump)
+  set_tests_properties(Compare_csg_dump_output PROPERTIES LABELS "csg;tools;votca")
 endif()

--- a/src/tools/csg_dlptopol.cc
+++ b/src/tools/csg_dlptopol.cc
@@ -140,15 +140,30 @@ bool DLPTopolApp::EvaluateTopology(Topology *top, Topology *top_ref)
     // collect unique bead pairs over all molecular types found
 
     for(int ib1=0; ib1<mol->BeadCount(); ib1++) {
-      string bead_name1 = mol->getBead(ib1)->getType()->getName();
+      //string bead_name1 = mol->getBead(ib1)->getType()->getName();
+      auto weak_type = mol->getBead(ib1)->getType();
+
+      string bead_name1;
+      if(auto type = weak_type.lock()){
+        bead_name1 = type->getName();
+      }else{
+        throw runtime_error("bead type is inaccessible in csg_dlptopol.cc.");
+      }
       bead_name1 = bead_name1.substr(0,bead_name1.find_first_of("#")); // skip #index of atom from its name
 
       for(unsigned int imt=0; imt<MolecularTypes.size(); imt++) {
 
 	for(int ib2=0; ib2<MolecularTypes[imt]->BeadCount(); ib2++) {
 
-	  string bead_name2 = MolecularTypes[imt]->getBead(ib2)->getType()->getName();
-	  bead_name2 = bead_name2.substr(0,bead_name2.find_first_of("#")); // skip #index of atom from its name
+	 // string bead_name2 = MolecularTypes[imt]->getBead(ib2)->getType()->getName();
+      auto weak_type = MolecularTypes[imt]->getBead(ib2)->getType();
+      string bead_name2;
+      if(auto type = weak_type.lock()){
+        bead_name2 = type->getName();
+      }else{
+        throw runtime_error("Bead type inaccessible in csg_dlptopol.");
+      }
+    bead_name2 = bead_name2.substr(0,bead_name2.find_first_of("#")); // skip #index of atom from its name
 
 	  stringstream ss_bp1,ss_bp2;
 
@@ -218,8 +233,15 @@ void DLPTopolApp::WriteMoleculeAtoms(ostream &out, Molecule &cg)
         Bead *b=cg.getBead(i);
 
         string bname=b->getName();
-        string btype=b->getType()->getName();
-	
+        //string btype=b->getType()->getName();
+	      string btype;
+        auto weak_type = b->getType();
+        if(auto type = weak_type.lock()){
+          btype = type->getName();
+        }else{
+          throw runtime_error("bead type is inaccessible in write molecule atoms in dlptopol.cc");
+        }
+
         bname = bname.substr(0,bname.find_first_of("#")); // skip #index of atom from its name
         btype = btype.substr(0,btype.find_first_of("#")); // skip #index of atom from its type
 

--- a/src/tools/csg_dump.cc
+++ b/src/tools/csg_dump.cc
@@ -77,23 +77,29 @@ bool CsgDumpApp::EvaluateTopology(Topology *top, Topology *top_ref)
 	    " id: " << top->getResidue(i)->getId() << endl;
 	}
 
-        cout << "\nList of molecules:\n";
-        MoleculeContainer::iterator mol;
-        for (mol = top->Molecules().begin(); mol != top->Molecules().end(); ++mol) {
-            cout << "molecule: " << (*mol)->getId() + 1 << " " << (*mol)->getName()
-                    << " beads: " << (*mol)->BeadCount() << endl;
-            for (int i = 0; i < (*mol)->BeadCount(); ++i) {
-	        int resnr=(*mol)->getBead(i)->getResnr();
-                cout << (*mol)->getBeadId(i) << " Name " <<
-                        (*mol)->getBeadName(i) << " Type " <<
-			(*mol)->getBead(i)->getType()->getName() << " Mass " <<
-			(*mol)->getBead(i)->getMass() << " Resnr " <<
-			resnr << " Resname " <<
-			top->getResidue(resnr)->getName() << " Charge " <<
-			(*mol)->getBead(i)->getQ() <<
-			endl;
-            }
-        }
+  cout << "\nList of molecules:\n";
+  MoleculeContainer::iterator mol;
+  for (mol = top->Molecules().begin(); mol != top->Molecules().end(); ++mol) {
+    cout << "molecule: " << (*mol)->getId() + 1 << " " << (*mol)->getName()
+      << " beads: " << (*mol)->BeadCount() << endl;
+    for (int i = 0; i < (*mol)->BeadCount(); ++i) {
+      int resnr=(*mol)->getBead(i)->getResnr();
+
+      auto weak_type = (*mol)->getBead(i)->getType();
+      if(auto type = weak_type.lock()){
+      cout << (*mol)->getBeadId(i) << " Name " <<
+        (*mol)->getBeadName(i) << " Type " <<
+        type->getName() << " Mass " <<
+        (*mol)->getBead(i)->getMass() << " Resnr " <<
+        resnr << " Resname " <<
+        top->getResidue(resnr)->getName() << " Charge " <<
+        (*mol)->getBead(i)->getQ() <<
+        endl;
+      }else{
+        throw runtime_error("Error cannot access beadtype in csg_dump.");
+      }
+    }
+  }
     }
     else {
         cout << "\nList of exclusions:\n" << top->getExclusions();

--- a/src/tools/csg_gmxtopol.cc
+++ b/src/tools/csg_gmxtopol.cc
@@ -76,9 +76,14 @@ void GmxTopolApp::WriteAtoms(ostream &out, Molecule &cg)
     out << "; nr type resnr residue atom cgnr charge mass\n";
     for(int i=0; i<cg.BeadCount(); ++i) {
         Bead *b=cg.getBead(i);
-       
+        auto weak_type = b->getType();
+        if(auto type = weak_type.lock()){ 
         out << format("%d %s 1 RES %s %d %f %f\n")
-            % (i+1) % b->getType()->getName() % b->getName() % (i+1) % b->getQ() % b->getMass();
+            % (i+1) % type->getName() % b->getName() % (i+1) % b->getQ() % b->getMass();
+        }else{
+          throw runtime_error("Cannot access bead type in csg gmxtopol as it is inacccessible.");
+        }
+        
     }
     out << endl;
 }

--- a/src/tools/csg_map.cc
+++ b/src/tools/csg_map.cc
@@ -96,8 +96,12 @@ void EvalConfiguration(Topology *top, Topology *top_ref) {
                     int beadid = (*it_mol)->getBead(i)->getId();
 
                     Bead *bi = (*it_mol)->getBead(i);
-                    auto type = hybtol->GetOrCreateBeadType(bi->getType()->getName());
-                    Bead *bn = hybtol->CreateBead(bi->getSymmetry(), bi->getName(), type, bi->getResnr(), bi->getMass(), bi->getQ());
+                    auto weak_type = bi->getType();
+                    if(!weak_type.lock()){
+                      throw runtime_error("Error bead type is inaccessible in csg_map.");
+                    }
+                      //auto type = hybtol->GetOrCreateBeadType(bi->getType()->getName());
+                    Bead *bn = hybtol->CreateBead(bi->getSymmetry(), bi->getName(), weak_type, bi->getResnr(), bi->getMass(), bi->getQ());
                     bn->setOptions(bi->Options());
                     bn->setPos(bi->getPos());
                     if (bi->HasVel()) bn->setVel(bi->getVel());
@@ -114,8 +118,12 @@ void EvalConfiguration(Topology *top, Topology *top_ref) {
                         Bead *bi = cgmol->getBead(i);
                         // todo: this is a bit dirty as a cg bead will always have the resid of its first parent
                         Bead *bparent = (*it_mol)->getBead(0);
-                        auto type = hybtol->GetOrCreateBeadType(bi->getType()->getName());
-                        Bead *bn = hybtol->CreateBead(bi->getSymmetry(), bi->getName(), type, bparent->getResnr(), bi->getMass(), bi->getQ());
+                        auto weak_type = bi->getType();
+                        //auto weak_type = hybtol->GetOrCreateBeadType(bi->getType()->getName());
+                        if(!weak_type.lock()){
+                          throw runtime_error("Error bead type is inaccessible in csg_map.");
+                        }
+                        Bead *bn = hybtol->CreateBead(bi->getSymmetry(), bi->getName(), weak_type, bparent->getResnr(), bi->getMass(), bi->getQ());
                         bn->setOptions(bi->Options());
                         bn->setPos(bi->getPos());
                         if (bi->HasVel()) bn->setVel(bi->getVel());

--- a/src/tools/references/methanol-water/csg_dump.out
+++ b/src/tools/references/methanol-water/csg_dump.out
@@ -1,0 +1,18 @@
+I have 4 beads in 4 molecules
+Boundary Condition: open
+
+List of residues:
+0 name: MEO id: 0
+1 name: MEO id: 1
+2 name: SOL id: 2
+3 name: SOL id: 3
+
+List of molecules:
+molecule: 1 MEO beads: 1
+0 Name 1:MEO:ME Type ME Mass 32.0424 Resnr 0 Resname MEO Charge 0
+molecule: 2 MEO beads: 1
+1 Name 1:MEO:ME Type ME Mass 32.0424 Resnr 1 Resname MEO Charge 0
+molecule: 3 SOL beads: 1
+2 Name 2:SOL:WT Type WT Mass 18.0154 Resnr 2 Resname SOL Charge 0
+molecule: 4 SOL beads: 1
+3 Name 2:SOL:WT Type WT Mass 18.0154 Resnr 3 Resname SOL Charge 0

--- a/src/tools/references/methanol-water/topol_cg.xml
+++ b/src/tools/references/methanol-water/topol_cg.xml
@@ -1,0 +1,11 @@
+<topology>
+  <molecules>
+    <molecule name="MEO" nmols="2" nbeads="1">
+      <bead name="ME" type="ME" mass="32.0424" q="0" />
+    </molecule>
+    <molecule name="SOL" nmols="2" nbeads="1">
+      <bead name="WT" type="WT" mass="18.0154" q="0" />
+    </molecule>
+  </molecules>
+</topology>
+


### PR DESCRIPTION
@junghans your test is implemented here already. By switching to shared and weak pointers for the beadtype, the tests pass locally on ubuntu. I'm still unsure as to what the underlying cause is though. Let me check if valgrind is still finding problems before we merge. I would also like to cleanup the code a bit before. 