### PR TITLE
Removed test that was checking for exceptions

### DIFF
--- a/src/tests/test_beadstructure_base.cc
+++ b/src/tests/test_beadstructure_base.cc
@@ -300,15 +300,6 @@ BOOST_AUTO_TEST_CASE(test_beadstructure_getNeighBeads) {
 BOOST_AUTO_TEST_CASE(test_beadstructure_catchError) {
 
   {
-    // Intentionally fail to set id
-    TestBead testbead1;
-    testbead1.setName("Hydrogen");
-
-    BeadStructure beadstructure1;
-    BOOST_CHECK_THROW(beadstructure1.AddBead(&testbead1), runtime_error);
-  }
-
-  {
     TestBead testbead1;
     testbead1.setName("Hydrogen");
     testbead1.setId(1);


### PR DESCRIPTION
An exception was being tested for in the beadstructure algorithm this is no longer needed as that exception was replaced with an assertion for performance reasons. 