### PR TITLE
csg_get_interaction_property: fix for multiple maps

### DIFF
--- a/share/scripts/inverse/functions_common.sh
+++ b/share/scripts/inverse/functions_common.sh
@@ -270,7 +270,7 @@ csg_get_interaction_property () { #gets an interaction property from the xml fil
       for map in ${mapping}; do
         [[ -f "$(get_main_dir)/$map" ]] || die "${FUNCNAME[0]}: Mapping file '$map' for bonded interaction not found in maindir"
 	names+=( $(critical -q csg_property --file "$(get_main_dir)/$map" --path cg_molecule.topology.cg_bonded.*.name --print . --short) )
-	dup=$(has_duplicate "${names[@]}") && die "${FUNCNAME[0]}: cg_bonded name '$dup' appears twice in file(s) $mapping"
+	[[ -n ${names[@]} ]] && dup=$(has_duplicate "${names[@]}") && die "${FUNCNAME[0]}: cg_bonded name '$dup' appears twice in file(s) $mapping"
         ret2="$(critical -q csg_property --file "$(get_main_dir)/$map" --path cg_molecule.topology.cg_bonded.* --filter name="$bondname" --print . --with-path | trim_all)"
         ret2="$(echo "$ret2" | critical sed -n 's/.*cg_bonded\.\([^[:space:]]*\) .*/\1/p')"
 	if [[ -n $ret2 ]]; then


### PR DESCRIPTION
In case the user uses multiple mapping file not all
of them necessarily contain bonded interactions and
hence ${names} can be empty. However when it is
empty, one does not need to check for duplicates.

Reported here: https://groups.google.com/d/topic/votca/FeiWkerlngE/discussion