### PR TITLE
.gitlab-ci.yml: allow rawhide builds to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,6 +132,7 @@ Debug GCC Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Debug Clang Rawhide:
   variables:
@@ -140,6 +141,7 @@ Debug Clang Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Rawhide:
   variables:
@@ -148,6 +150,7 @@ Release GCC Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release Clang Rawhide:
   variables:
@@ -156,6 +159,7 @@ Release Clang Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Minimal:
   variables:


### PR DESCRIPTION
Part of https://github.com/votca/votca/pull/159

Workaround for https://github.com/openucx/ucx/issues/3558