### PR TITLE
Electrostatics add labels to tests

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -26,5 +26,5 @@ foreach(PROG
   target_compile_definitions(unit_${PROG} PRIVATE BOOST_TEST_DYN_LINK)
   add_test(unit_${PROG} unit_${PROG})
   # run tests for csg (for coverage) as well
-  set_tests_properties(unit_${PROG} PROPERTIES LABELS "csg;votca")
+  set_tests_properties(unit_${PROG} PROPERTIES LABELS "csg;votca;unit")
 endforeach(PROG)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(PROG csg_reupdate csg_map csg_dump csg_property csg_resample csg_stat cs
   if(ENABLE_TESTING)
     add_test(integration_${PROG}Help ${PROG} --help)
     # run tests for tools (for coverage) as well
-    set_tests_properties(integration_${PROG}Help PROPERTIES LABELS "csg;tools;votca")
+    set_tests_properties(integration_${PROG}Help PROPERTIES LABELS "csg;tools;votca;integration")
   endif(ENABLE_TESTING)
 endforeach(PROG)
 
@@ -29,10 +29,10 @@ if(ENABLE_TESTING)
   file(MAKE_DIRECTORY ${RUNPATH})
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${REFPATH}/CG-CG.param.in_re ${RUNPATH}/CG-CG.param.cur)
   add_test(NAME integration_Run_csg_reupdate COMMAND csg_reupdate --gentable true --options ${REFPATH}/settings_re.xml WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_reupdate PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_reupdate PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_reupdate_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.pot.new -f2 ${REFPATH}/CG-CG.pot.re WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_reupdate_output PROPERTIES DEPENDS Run_csg_reupdate)
-  set_tests_properties(integration_Compare_csg_reupdate_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_reupdate_output PROPERTIES LABELS "csg;tools;votca;integration")
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_fmatch)
   file(MAKE_DIRECTORY ${RUNPATH})
@@ -40,10 +40,10 @@ if(ENABLE_TESTING)
     COMMAND csg_fmatch --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump --options ${REFPATH}/settings_fmatch.xml
                       --cg ${REFPATH}/mapping.xml 
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_fmatch PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_fmatch PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_fmatch_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.force -f2 ${REFPATH}/CG-CG.force.fmatch WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_fmatch_output PROPERTIES DEPENDS integration_Run_csg_fmatch)
-  set_tests_properties(integration_Compare_csg_fmatch_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_fmatch_output PROPERTIES LABELS "csg;tools;votca;integration")
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_fmatch_3body)
   file(MAKE_DIRECTORY ${RUNPATH})
@@ -51,26 +51,26 @@ if(ENABLE_TESTING)
     COMMAND csg_fmatch --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump --options ${REFPATH}/settings_fmatch_3body.xml
                       --cg ${REFPATH}/mapping.xml 
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_fmatch_3body PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_fmatch_3body PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_fmatch_3body_output1 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.force -f2 ${REFPATH}/CG-CG.force.fmatch_3body WORKING_DIRECTORY ${RUNPATH})
   add_test(NAME integration_Compare_csg_fmatch_3body_output2 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG-CG.force -f2 ${REFPATH}/CG-CG-CG.force.fmatch_3body WORKING_DIRECTORY ${RUNPATH})
   add_test(NAME integration_Compare_csg_fmatch_3body_output3 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG-CG.pot -f2 ${REFPATH}/CG-CG-CG.pot.fmatch_3body WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_fmatch_3body_output1 PROPERTIES DEPENDS integration_Run_csg_fmatch)
-  set_tests_properties(integration_Compare_csg_fmatch_3body_output1 PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_fmatch_3body_output1 PROPERTIES LABELS "csg;tools;votca;integration")
   set_tests_properties(integration_Compare_csg_fmatch_3body_output2 PROPERTIES DEPENDS integration_Run_csg_fmatch)
-  set_tests_properties(integration_Compare_csg_fmatch_3body_output2 PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_fmatch_3body_output2 PROPERTIES LABELS "csg;tools;votca;integration")
   set_tests_properties(integration_Compare_csg_fmatch_3body_output3 PROPERTIES DEPENDS integration_Run_csg_fmatch)
-  set_tests_properties(integration_Compare_csg_fmatch_3body_output3 PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_fmatch_3body_output3 PROPERTIES LABELS "csg;tools;votca;integration")
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_map)
   file(MAKE_DIRECTORY ${RUNPATH})
   add_test(NAME integration_Run_csg_map
     COMMAND csg_map --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump --out frame.dump --no-map --force
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_map PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_map PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_map_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 frame.dump -f2 ${REFPATH}/frame.dump WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_map_output PROPERTIES DEPENDS integration_Run_csg_map)
-  set_tests_properties(integration_Compare_csg_map_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_map_output PROPERTIES LABELS "csg;tools;votca;integration")
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_stat)
   file(MAKE_DIRECTORY ${RUNPATH})
@@ -78,13 +78,13 @@ if(ENABLE_TESTING)
     COMMAND csg_stat --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump
                      --options  ${REFPATH}/settings_rdf.xml --cg ${REFPATH}/mapping.xml
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_stat PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_stat PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_stat_output1 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.dist.new -f2 ${REFPATH}/CG-CG.rdf WORKING_DIRECTORY ${RUNPATH})
   add_test(NAME integration_Compare_csg_stat_output2 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.force.new -f2 ${REFPATH}/CG-CG.pmf WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_stat_output1 PROPERTIES DEPENDS integration_Run_csg_stat)
-  set_tests_properties(integration_Compare_csg_stat_output1 PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_stat_output1 PROPERTIES LABELS "csg;tools;votca;integration")
   set_tests_properties(integration_Compare_csg_stat_output2 PROPERTIES DEPENDS integration_Run_csg_stat)
-  set_tests_properties(integration_Compare_csg_stat_output2 PROPERTIES LABELS "csg;tools;votca") 
+  set_tests_properties(integration_Compare_csg_stat_output2 PROPERTIES LABELS "csg;tools;votca;integration") 
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_stat_angular)
   file(MAKE_DIRECTORY ${RUNPATH})
@@ -92,10 +92,10 @@ if(ENABLE_TESTING)
     COMMAND csg_stat --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump
                      --options  ${REFPATH}/settings_angular.xml --cg ${REFPATH}/mapping.xml
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_stat_angular PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_stat_angular PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_stat_angular_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG-CG.dist.new -f2 ${REFPATH}/CG-CG-CG.angular WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_stat_angular_output PROPERTIES DEPENDS integration_Run_csg_stat_angular)
-  set_tests_properties(integration_Compare_csg_stat_angular_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_stat_angular_output PROPERTIES LABELS "csg;tools;votca;integration")
 
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_stat-imc)
   file(MAKE_DIRECTORY ${RUNPATH})
@@ -104,13 +104,13 @@ if(ENABLE_TESTING)
     COMMAND csg_stat --top ${REFPATH}/topol.xml --trj ${REFPATH}/frame.dump --do-imc
                      --options  ${REFPATH}/settings_imc.xml --cg ${REFPATH}/mapping.xml
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_stat-imc PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_stat-imc PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_stat-imc_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.imc -f2 ${REFPATH}/CG-CG.imc WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_stat-imc_output PROPERTIES DEPENDS integration_Run_csg_stat-imc)
-  set_tests_properties(integration_Compare_csg_stat-imc_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_stat-imc_output PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_stat-imc_output_2 COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 CG-CG.dist.new -f2 ${REFPATH}/CG-CG.dist.imc WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_stat-imc_output_2 PROPERTIES DEPENDS integration_Run_csg_stat-imc)
-  set_tests_properties(integration_Compare_csg_stat-imc_output_2 PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_stat-imc_output_2 PROPERTIES LABELS "csg;tools;votca;integration")
   
   set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_resample)
   set(REFPATH ${CMAKE_CURRENT_SOURCE_DIR}/references/csg_resample)
@@ -118,31 +118,31 @@ if(ENABLE_TESTING)
   add_test(NAME integration_Run_csg_resample_akima
     COMMAND csg_resample --in ${REFPATH}/table_in --out table_akima --type akima --grid 0:0.1:3
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_resample_akima PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_resample_akima PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_resample_akima_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 table_akima -f2 ${REFPATH}/table_akima WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_resample_akima_output PROPERTIES DEPENDS integration_Run_csg_resample_akima)
-  set_tests_properties(integration_Compare_csg_resample_akima_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_resample_akima_output PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Run_csg_resample_cubic
     COMMAND csg_resample --in ${REFPATH}/table_in --out table_cubic --type cubic --grid 0:0.1:3
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_resample_cubic PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_resample_cubic PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_resample_cubic_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 table_cubic -f2 ${REFPATH}/table_cubic WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_resample_cubic_output PROPERTIES DEPENDS integration_Run_csg_resample_cubic)
-  set_tests_properties(integration_Compare_csg_resample_cubic_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_resample_cubic_output PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Run_csg_resample_linear
     COMMAND csg_resample --in ${REFPATH}/table_in --out table_linear --type linear --grid 0:0.1:3
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_resample_linear PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_resample_linear PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_resample_linear_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 table_linear -f2 ${REFPATH}/table_linear WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_resample_linear_output PROPERTIES DEPENDS integration_Run_csg_resample_linear)
-  set_tests_properties(integration_Compare_csg_resample_linear_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_resample_linear_output PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Run_csg_resample_cubicfit
     COMMAND csg_resample --in ${REFPATH}/table_in --out table_cubicfit --type cubic --grid 0:1:9 --fitgrid 0:2:9
     WORKING_DIRECTORY ${RUNPATH})
-  set_tests_properties(integration_Run_csg_resample_cubicfit PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Run_csg_resample_cubicfit PROPERTIES LABELS "csg;tools;votca;integration")
   add_test(NAME integration_Compare_csg_resample_cubicfit_output COMMAND $<TARGET_FILE:VOTCA::votca_compare> --etol ${REGRESSIONTEST_TOLERANCE} -f1 table_cubicfit -f2 ${REFPATH}/table_cubicfit WORKING_DIRECTORY ${RUNPATH})
   set_tests_properties(integration_Compare_csg_resample_cubicfit_output PROPERTIES DEPENDS integration_Run_csg_resample_cubicfit)
-  set_tests_properties(integration_Compare_csg_resample_cubicfit_output PROPERTIES LABELS "csg;tools;votca")
+  set_tests_properties(integration_Compare_csg_resample_cubicfit_output PROPERTIES LABELS "csg;tools;votca;integration")
  
   if(BASH)
     set(RUNPATH ${CMAKE_CURRENT_BINARY_DIR}/Run_csg_dump)
@@ -151,9 +151,9 @@ if(ENABLE_TESTING)
     add_test(NAME integration_Run_csg_dump
       COMMAND ${BASH} -c "$<TARGET_FILE:csg_dump> --top ${REFPATH}/topol_cg.xml > csg_dump.out"
       WORKING_DIRECTORY ${RUNPATH})
-    set_tests_properties(integration_Run_csg_dump PROPERTIES LABELS "csg;tools;votca")
+    set_tests_properties(integration_Run_csg_dump PROPERTIES LABELS "csg;tools;votca;integration")
     add_test(NAME integration_Compare_csg_dump_output COMMAND ${CMAKE_COMMAND} -E compare_files csg_dump.out ${REFPATH}/csg_dump.out WORKING_DIRECTORY ${RUNPATH})
     set_tests_properties(integration_Compare_csg_dump_output PROPERTIES DEPENDS integration_Run_csg_dump)
-    set_tests_properties(integration_Compare_csg_dump_output PROPERTIES LABELS "csg;tools;votca")
+    set_tests_properties(integration_Compare_csg_dump_output PROPERTIES LABELS "csg;tools;votca;integration")
   endif(BASH)
 endif()


### PR DESCRIPTION
Add labels to tests, to make it easier to run the appropriate test sets using label identifiers. 