### PR TITLE
Fix: bug related to header line, https://github.com/votca/csg/issues/370

### DIFF
--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -143,7 +143,6 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
   getline(fl_, line);
   while (!fl_.eof()) {
 
-    bool labelMatched = false;
     Tokenizer tok(line, " ");
     vector<string> fields;
     tok.ToVector(fields);
@@ -151,13 +150,13 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
     // If not check the size of the vector and parse according
     // to the number of fields
     if (fields.size() == 1) {
-      labelMatched = MatchOneFieldLabel_(fields, top);
+      MatchOneFieldLabel_(fields, top);
     } else if (fields.size() == 2) {
-      labelMatched = MatchTwoFieldLabels_(fields, top);
+      MatchTwoFieldLabels_(fields, top);
     } else if (fields.size() == 3) {
-      labelMatched = MatchThreeFieldLabels_(fields, top);
+      MatchThreeFieldLabels_(fields, top);
     } else if (fields.size() == 4) {
-      labelMatched = MatchFourFieldLabels_(fields, top);
+      MatchFourFieldLabels_(fields, top);
     } else if (fields.size() != 0) {
       string err = "Unrecognized line in lammps .data file:\n" + line;
       throw runtime_error(err);

--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,11 +135,12 @@ bool LAMMPSDataReader::FirstFrame(Topology &top) {
 
 bool LAMMPSDataReader::NextFrame(Topology &top) {
 
-  string line;
-  getline(fl_, line);
+  string header;
+  getline(fl_, header);
   while (!fl_.eof()) {
 
     bool labelMatched = false;
+    string line;
     Tokenizer tok(line, " ");
     vector<string> fields;
     tok.ToVector(fields);

--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -82,6 +82,8 @@ string getStringGivenDoubleAndMap_(double value, map<string, double> nameValue,
  * Public Facing Methods                                                     *
  *****************************************************************************/
 
+// Data file should follow this format: 
+// https://lammps.sandia.gov/doc/2001/data_format.html
 bool LAMMPSDataReader::ReadTopology(string file, Topology &top) {
 
   cout << endl;
@@ -137,10 +139,11 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
 
   string header;
   getline(fl_, header);
+  string line;
+  getline(fl_, line);
   while (!fl_.eof()) {
 
     bool labelMatched = false;
-    string line;
     Tokenizer tok(line, " ");
     vector<string> fields;
     tok.ToVector(fields);
@@ -156,14 +159,8 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
     } else if (fields.size() == 4) {
       labelMatched = MatchFourFieldLabels_(fields, top);
     } else if (fields.size() != 0) {
-
-      // See if the line is the lammps .data header/info line
-      labelMatched = MatchFieldsTimeStepLabel_(fields, top);
-
-      if (!labelMatched) {
-        string err = "Unrecognized line in lammps .data file:\n" + line;
-        throw runtime_error(err);
-      }
+      string err = "Unrecognized line in lammps .data file:\n" + line;
+      throw runtime_error(err);
     }
     getline(fl_, line);
   }
@@ -252,19 +249,6 @@ bool LAMMPSDataReader::MatchFourFieldLabels_(vector<string> fields,
     return false;
   }
   return true;
-}
-
-bool LAMMPSDataReader::MatchFieldsTimeStepLabel_(vector<string> fields,
-                                                 Topology &top) {
-  size_t index = 0;
-  for (auto field : fields) {
-    if (field == "timestep" && (index + 2) < fields.size()) {
-      top.setStep(stoi(fields.at(index + 2)));
-      return true;
-    }
-    ++index;
-  }
-  return false;
 }
 
 void LAMMPSDataReader::InitializeAtomAndBeadTypes_() {

--- a/src/libcsg/modules/io/lammpsdatareader.h
+++ b/src/libcsg/modules/io/lammpsdatareader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +89,6 @@ private:
   bool MatchTwoFieldLabels_(std::vector<std::string> fields, Topology &top);
   bool MatchThreeFieldLabels_(std::vector<std::string> fields, Topology &top);
   bool MatchFourFieldLabels_(std::vector<std::string> fields, Topology &top);
-  bool MatchFieldsTimeStepLabel_(std::vector<std::string> fields,
-                                 Topology &top);
 
   void ReadBox_(std::vector<std::string> fields, Topology &top);
   void SortIntoDataGroup_(std::string tag);

--- a/src/tests/test_lammpsdatareader.cc
+++ b/src/tests/test_lammpsdatareader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,8 +85,6 @@ BOOST_AUTO_TEST_CASE(test_topologyreader){
 	auto mol = top.getMolecule(0);
 	BOOST_CHECK_EQUAL(mol->BeadCount(),100);
 
-	BOOST_CHECK_EQUAL(top.getStep(),961);
-
 	auto interaction_cont = top.BondedInteractions();
 	int numBondInter = 99;
 	int numAngleInter = 98;
@@ -156,8 +154,6 @@ BOOST_AUTO_TEST_CASE(test_trajectoryreader){
   
 	auto mol = top.getMolecule(0);
 	BOOST_CHECK_EQUAL(mol->BeadCount(),100);
-
-	BOOST_CHECK_EQUAL(top.getStep(),1010);
 
 	auto interaction_cont = top.BondedInteractions();
 	int numBondInter = 99;


### PR DESCRIPTION
The lammps data reader was not accounting for the header line, and was incorrectly throwing errors because none of the keywords were matching with the comments. 

Fix #370