### PR TITLE
fix: bead labels and types corrected in lammps data reader

### DIFF
--- a/src/libcsg/modules/io/lammpsdatareader.h
+++ b/src/libcsg/modules/io/lammpsdatareader.h
@@ -105,7 +105,7 @@ class LAMMPSDataReader : public TrajectoryReader, public TopologyReader {
   void ReadBonds_(Topology &top);
   void ReadAngles_(Topology &top);
   void ReadDihedrals_(Topology &top);
-  void ReadImpropers_(Topology &top);
+  void SkipImpropers_();
 
   void RenameMolecule(Molecule &mol) const;
 


### PR DESCRIPTION
Added some error checking messages, to help the user debug their data file, also fixed the bead type and name. 