### PR TITLE
fixed alignment problem

### DIFF
--- a/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
+++ b/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
@@ -67,7 +67,10 @@ class PotentialFunctionCBSPL : public PotentialFunction {
   double _dr;
   Eigen::VectorXd _rbreak;
 
-  // this shoudl not be a 4x4 matrix because of alignment problems
+  // this should not be a 4x4 matrix because of alignment problems
+  // as certain eigen datastructures require alignment modifiers if 
+  // stored in std:: datastructures, to avoid making the code more 
+  // complicated, we revert back to dynamic sized matrices here.
   Eigen::MatrixXd _M;
 };
 }  // namespace csg

--- a/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
+++ b/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
@@ -68,8 +68,8 @@ class PotentialFunctionCBSPL : public PotentialFunction {
   Eigen::VectorXd _rbreak;
 
   // this should not be a 4x4 matrix because of alignment problems
-  // as certain eigen datastructures require alignment modifiers if 
-  // stored in std:: datastructures, to avoid making the code more 
+  // as certain eigen datastructures require alignment modifiers if
+  // stored in std:: datastructures, to avoid making the code more
   // complicated, we revert back to dynamic sized matrices here.
   Eigen::MatrixXd _M;
 };

--- a/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
+++ b/include/votca/csg/potentialfunctions/potentialfunctioncbspl.h
@@ -67,7 +67,8 @@ class PotentialFunctionCBSPL : public PotentialFunction {
   double _dr;
   Eigen::VectorXd _rbreak;
 
-  Eigen::Matrix4d _M;
+  // this shoudl not be a 4x4 matrix because of alignment problems
+  Eigen::MatrixXd _M;
 };
 }  // namespace csg
 }  // namespace votca

--- a/src/libcsg/potentialfunctions/potentialfunctioncbspl.cc
+++ b/src/libcsg/potentialfunctions/potentialfunctioncbspl.cc
@@ -84,7 +84,7 @@ PotentialFunctionCBSPL::PotentialFunctionCBSPL(const string &name, Index nlam,
         "3. Use more knot values.\n");
   }
 
-  _M = Eigen::Matrix4d::Zero();
+  _M = Eigen::MatrixXd::Zero(4, 4);
   _M(0, 0) = 1.0;
   _M(0, 1) = 4.0;
   _M(0, 2) = 1.0;


### PR DESCRIPTION
certain eigen datastructures require alignment modifiers if stored in std:: datastructures, to avoid making the code more complicated, we revert back to dynamic sized matrices here.

same as https://github.com/votca/csg/pull/470

Fix #470 

https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html