### PR TITLE
changed from Index type (long int) to int as version array is of HDF5

### DIFF
--- a/src/libcsg/modules/io/h5mdtrajectoryreader.cc
+++ b/src/libcsg/modules/io/h5mdtrajectoryreader.cc
@@ -56,7 +56,7 @@ bool H5MDTrajectoryReader::Open(const string &file) {
 
   hid_t at_version = H5Aopen(g_h5md, "version", H5P_DEFAULT);
   CheckError(at_version, "Unable to read version attribute.");
-  Index version[2];
+  int version[2] = {0, 0};
   H5Aread(at_version, H5Aget_type(at_version), &version);
   if (version[0] != 1 || version[1] > 1) {
     cout << "Found H5MD version: " << version[0] << "." << version[1] << endl;


### PR DESCRIPTION
type H5T_STD_I32LE, which is mapped to int type
(https://support.hdfgroup.org/HDF5/release/dttable.html)

Backport of #477 