### PR TITLE
Fix includes

### DIFF
--- a/include/votca/csg/basebead.h
+++ b/include/votca/csg/basebead.h
@@ -18,9 +18,9 @@
 #ifndef VOTCA_CSG_BASEBEAD_H
 #define VOTCA_CSG_BASEBEAD_H
 
+#include "topologyitem.h"
 #include <assert.h>
 #include <memory>
-#include <votca/csg/topologyitem.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/eigen.h>
 #include <votca/tools/name.h>

--- a/include/votca/csg/pdbwriter.h
+++ b/include/votca/csg/pdbwriter.h
@@ -18,9 +18,9 @@
 #ifndef _PDBWRITER_H
 #define _PDBWRITER_H
 
+#include "topology.h"
+#include "trajectorywriter.h"
 #include <stdio.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/unitconverter.h>
 

--- a/include/votca/csg/xyzreader.h
+++ b/include/votca/csg/xyzreader.h
@@ -18,11 +18,11 @@
 #ifndef __VOTCA_CSG_XYZREADER_H
 #define __VOTCA_CSG_XYZREADER_H
 
+#include "topologyreader.h"
+#include "trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/unitconverter.h>
 

--- a/include/votca/csg/xyzwriter.h
+++ b/include/votca/csg/xyzwriter.h
@@ -18,9 +18,9 @@
 #ifndef __VOTCA_CSG_XYZWRITER_H
 #define __VOTCA_CSG_XYZWRITER_H
 
+#include "topology.h"
+#include "trajectorywriter.h"
 #include <stdio.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/unitconverter.h>
 

--- a/src/csg_boltzmann/analysistool.h
+++ b/src/csg_boltzmann/analysistool.h
@@ -18,10 +18,10 @@
 #ifndef VOTCA_CSG_ANALYSISTOOL_H
 #define VOTCA_CSG_ANALYSISTOOL_H
 
+#include "../../include/votca/csg/cgengine.h"
 #include "bondedstatistics.h"
 #include <map>
 #include <string>
-#include <votca/csg/cgengine.h>
 
 /**
     \brief base class for all analysis tools

--- a/src/csg_boltzmann/bondedstatistics.h
+++ b/src/csg_boltzmann/bondedstatistics.h
@@ -18,7 +18,7 @@
 #ifndef VOTCA_CSG_BONDEDSTATISTICS_H
 #define VOTCA_CSG_BONDEDSTATISTICS_H
 
-#include <votca/csg/cgobserver.h>
+#include "../../include/votca/csg/cgobserver.h"
 #include <votca/tools/datacollection.h>
 
 namespace votca {

--- a/src/csg_boltzmann/main.cc
+++ b/src/csg_boltzmann/main.cc
@@ -19,6 +19,7 @@
 // here!
 //
 
+#include "../../include/votca/csg/csgapplication.h"
 #include "analysistool.h"
 #include "bondedstatistics.h"
 #include "stdanalysis.h"
@@ -28,7 +29,6 @@
 #include <map>
 #include <math.h>
 #include <string>
-#include <votca/csg/csgapplication.h>
 #include <votca/tools/rangeparser.h>
 #include <votca/tools/tokenizer.h>
 

--- a/src/csg_boltzmann/tabulatedpotential.cc
+++ b/src/csg_boltzmann/tabulatedpotential.cc
@@ -16,6 +16,7 @@
  */
 
 #include "tabulatedpotential.h"
+#include "../../include/votca/csg/version.h"
 #include "analysistool.h"
 #include "bondedstatistics.h"
 #include <boost/lexical_cast.hpp>
@@ -24,7 +25,6 @@
 #include <math.h>
 #include <string>
 #include <vector>
-#include <votca/csg/version.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/histogram.h>
 

--- a/src/libcsg/beadstructurealgorithms.cc
+++ b/src/libcsg/beadstructurealgorithms.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/beadstructurealgorithms.h>
+#include "../../include/votca/csg/beadstructurealgorithms.h"
 #include <votca/tools/graphalgorithm.h>
 using namespace std;
 using namespace votca::tools;

--- a/src/libcsg/boundarycondition.cc
+++ b/src/libcsg/boundarycondition.cc
@@ -15,8 +15,8 @@
  *
  */
 
+#include "../../include/votca/csg/boundarycondition.h"
 #include <vector>
-#include <votca/csg/boundarycondition.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/cgengine.cc
+++ b/src/libcsg/cgengine.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/cgengine.h"
+#include "../../include/votca/csg/version.h"
 #include <fstream>
-#include <votca/csg/cgengine.h>
-#include <votca/csg/version.h>
 #include <votca/tools/tokenizer.h>
 
 namespace votca {

--- a/src/libcsg/cgmoleculedef.cc
+++ b/src/libcsg/cgmoleculedef.cc
@@ -15,17 +15,17 @@
  *
  */
 
+#include "../../include/votca/csg/interaction.h"
 #include <boost/lexical_cast.hpp>
 #include <iostream>
-#include <votca/csg/interaction.h>
 #include <votca/tools/tokenizer.h>
 
+#include "../../include/votca/csg/cgmoleculedef.h"
+#include "../../include/votca/csg/map.h"
+#include "../../include/votca/csg/topology.h"
 #include <stddef.h>
 #include <stdexcept>
 #include <string>
-#include <votca/csg/cgmoleculedef.h>
-#include <votca/csg/map.h>
-#include <votca/csg/topology.h>
 #include <votca/tools/property.h>
 
 namespace votca {

--- a/src/libcsg/csgapplication.cc
+++ b/src/libcsg/csgapplication.cc
@@ -15,14 +15,14 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
+#include "../../include/votca/csg/cgengine.h"
+#include "../../include/votca/csg/topologymap.h"
+#include "../../include/votca/csg/topologyreader.h"
+#include "../../include/votca/csg/trajectoryreader.h"
+#include "../../include/votca/csg/trajectorywriter.h"
+#include "../../include/votca/csg/version.h"
 #include <boost/algorithm/string/trim.hpp>
-#include <votca/csg/cgengine.h>
-#include <votca/csg/csgapplication.h>
-#include <votca/csg/topologymap.h>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
-#include <votca/csg/trajectorywriter.h>
-#include <votca/csg/version.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/exclusionlist.cc
+++ b/src/libcsg/exclusionlist.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/exclusionlist.h"
+#include "../../include/votca/csg/topology.h"
 #include <algorithm>
-#include <votca/csg/exclusionlist.h>
-#include <votca/csg/topology.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/imcio.cc
+++ b/src/libcsg/imcio.cc
@@ -15,12 +15,12 @@
  *
  */
 
+#include "../../include/votca/csg/imcio.h"
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <votca/csg/imcio.h>
 #include <votca/tools/getline.h>
 #include <votca/tools/rangeparser.h>
 #include <votca/tools/table.h>

--- a/src/libcsg/map.cc
+++ b/src/libcsg/map.cc
@@ -15,11 +15,11 @@
  *
  */
 
+#include "../../include/votca/csg/map.h"
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/topology.h"
 #include <numeric>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/map.h>
-#include <votca/csg/topology.h>
 #include <votca/tools/eigen.h>
 #include <votca/tools/tokenizer.h>
 

--- a/src/libcsg/modules/io/dlpolytopologyreader.cc
+++ b/src/libcsg/modules/io/dlpolytopologyreader.cc
@@ -15,13 +15,13 @@
  *
  */
 
+#include "../../../../include/votca/csg/topology.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <votca/csg/topology.h>
 #include <votca/tools/getline.h>
 #include <votca/tools/tokenizer.h>
 

--- a/src/libcsg/modules/io/dlpolytopologyreader.h
+++ b/src/libcsg/modules/io/dlpolytopologyreader.h
@@ -18,9 +18,9 @@
 #ifndef _DLPTOPOLOGYREADER_H
 #define _DLPTOPOLOGYREADER_H
 
+#include "../../../../include/votca/csg/topology.h"
+#include "../../../../include/votca/csg/topologyreader.h"
 #include <string>
-#include <votca/csg/topology.h>
-#include <votca/csg/topologyreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/dlpolytrajectoryreader.cc
+++ b/src/libcsg/modules/io/dlpolytrajectoryreader.cc
@@ -16,12 +16,12 @@
  */
 
 #include "dlpolytrajectoryreader.h"
+#include "../../../../include/votca/csg/boundarycondition.h"
+#include "../../../../include/votca/csg/topology.h"
 #include <boost/filesystem/convenience.hpp>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <votca/csg/boundarycondition.h>
-#include <votca/csg/topology.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/getline.h>
 

--- a/src/libcsg/modules/io/dlpolytrajectoryreader.h
+++ b/src/libcsg/modules/io/dlpolytrajectoryreader.h
@@ -18,10 +18,10 @@
 #ifndef _dlpolytrajectoryreader_H
 #define _dlpolytrajectoryreader_H
 
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/dlpolytrajectorywriter.h
+++ b/src/libcsg/modules/io/dlpolytrajectorywriter.h
@@ -18,8 +18,8 @@
 #ifndef _DLPOLYTRAJECTORYWRITER_H
 #define _DLPOLYTRAJECTORYWRITER_H
 
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
+#include "../../../../include/votca/csg/topology.h"
+#include "../../../../include/votca/csg/trajectorywriter.h"
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/gmxtopologyreader.cc
+++ b/src/libcsg/modules/io/gmxtopologyreader.cc
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <string>
 
-#include <votca/csg/topology.h>
+#include "../../../../include/votca/csg/topology.h"
 
 #include "gmxtopologyreader.h"
 

--- a/src/libcsg/modules/io/gmxtopologyreader.h
+++ b/src/libcsg/modules/io/gmxtopologyreader.h
@@ -18,8 +18,8 @@
 #ifndef _VOTCA_CSG_GMXTOPOLOGYREADER_H
 #define _VOTCA_CSG_GMXTOPOLOGYREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
 #include <string>
-#include <votca/csg/topologyreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/gmxtrajectoryreader.cc
+++ b/src/libcsg/modules/io/gmxtrajectoryreader.cc
@@ -16,10 +16,10 @@
  */
 
 #include "gmxtrajectoryreader.h"
+#include "../../../../include/votca/csg/topology.h"
 #include <cstdlib>
 #include <gromacs/utility/programcontext.h>
 #include <iostream>
-#include <votca/csg/topology.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/modules/io/gmxtrajectoryreader.h
+++ b/src/libcsg/modules/io/gmxtrajectoryreader.h
@@ -22,8 +22,8 @@
 #include <votca_config.h>
 #endif
 
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <string>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/unitconverter.h>
 
 #include <gromacs/fileio/oenv.h>

--- a/src/libcsg/modules/io/gmxtrajectorywriter.h
+++ b/src/libcsg/modules/io/gmxtrajectorywriter.h
@@ -22,8 +22,8 @@
 #include <votca_config.h>
 #endif
 
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
+#include "../../../../include/votca/csg/topology.h"
+#include "../../../../include/votca/csg/trajectorywriter.h"
 #include <votca/tools/unitconverter.h>
 
 struct t_trxstatus;

--- a/src/libcsg/modules/io/groreader.h
+++ b/src/libcsg/modules/io/groreader.h
@@ -18,11 +18,11 @@
 #ifndef _VOTCA_CSG_GROREADER_H
 #define _VOTCA_CSG_GROREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/growriter.h
+++ b/src/libcsg/modules/io/growriter.h
@@ -18,9 +18,9 @@
 #ifndef _GROWRITER_H
 #define _GROWRITER_H
 
+#include "../../../../include/votca/csg/topology.h"
+#include "../../../../include/votca/csg/trajectorywriter.h"
 #include <stdio.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/h5mdtrajectoryreader.h
+++ b/src/libcsg/modules/io/h5mdtrajectoryreader.h
@@ -18,8 +18,8 @@
 #ifndef SRC_LIBCSG_MODULES_IO_H5MDTRAJECTORYREADER_H_
 #define SRC_LIBCSG_MODULES_IO_H5MDTRAJECTORYREADER_H_
 
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
+#include "../../../../include/votca/csg/topologyreader.h"
+#include "../../../../include/votca/csg/trajectoryreader.h"
 
 #include <cstdio>
 #include <fstream>

--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -16,9 +16,9 @@
  */
 
 #include "lammpsdatareader.h"
+#include "../../../../include/votca/csg/topology.h"
 #include <boost/algorithm/string.hpp>
 #include <vector>
-#include <votca/csg/topology.h>
 #include <votca/tools/elements.h>
 #include <votca/tools/floatingpointcomparison.h>
 #include <votca/tools/getline.h>

--- a/src/libcsg/modules/io/lammpsdatareader.h
+++ b/src/libcsg/modules/io/lammpsdatareader.h
@@ -18,11 +18,11 @@
 #ifndef _VOTCA_CSG_LAMMPSDATAREADER_H
 #define _VOTCA_CSG_LAMMPSDATAREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/lammpsdumpreader.h
+++ b/src/libcsg/modules/io/lammpsdumpreader.h
@@ -18,11 +18,11 @@
 #ifndef _VOTCA_CSG_LAMMPSDUMPREADER_H
 #define _VOTCA_CSG_LAMMPSDUMPREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/lammpsdumpwriter.h
+++ b/src/libcsg/modules/io/lammpsdumpwriter.h
@@ -18,9 +18,9 @@
 #ifndef __VOTCA_CSG_LAMMPSDUMPWRITER_H
 #define __VOTCA_CSG_LAMMPSDUMPWRITER_H
 
+#include "../../../../include/votca/csg/topology.h"
+#include "../../../../include/votca/csg/trajectorywriter.h"
 #include <stdio.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/unitconverter.h>
 
 namespace votca {

--- a/src/libcsg/modules/io/pdbreader.h
+++ b/src/libcsg/modules/io/pdbreader.h
@@ -18,11 +18,11 @@
 #ifndef __VOTCA_CSG_PDBREADER_H
 #define __VOTCA_CSG_PDBREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
+#include "../../../../include/votca/csg/trajectoryreader.h"
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
 #include <votca/tools/elements.h>
 #include <votca/tools/unitconverter.h>
 

--- a/src/libcsg/modules/io/pdbwriter.cc
+++ b/src/libcsg/modules/io/pdbwriter.cc
@@ -15,10 +15,10 @@
  *
  */
 
+#include "../../../../include/votca/csg/pdbwriter.h"
 #include <boost/format.hpp>
 #include <stdio.h>
 #include <string>
-#include <votca/csg/pdbwriter.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/modules/io/xmltopologyreader.h
+++ b/src/libcsg/modules/io/xmltopologyreader.h
@@ -18,10 +18,10 @@
 #ifndef _XMLTOPOLOGYREADER_H
 #define _XMLTOPOLOGYREADER_H
 
+#include "../../../../include/votca/csg/topologyreader.h"
 #include <boost/unordered_map.hpp>
 #include <stack>
 #include <string>
-#include <votca/csg/topologyreader.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/modules/io/xyzreader.cc
+++ b/src/libcsg/modules/io/xyzreader.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../../../include/votca/csg/xyzreader.h"
 #include <boost/lexical_cast.hpp>
 #include <vector>
-#include <votca/csg/xyzreader.h>
 #include <votca/tools/getline.h>
 namespace votca {
 namespace csg {

--- a/src/libcsg/modules/io/xyzwriter.cc
+++ b/src/libcsg/modules/io/xyzwriter.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../../../include/votca/csg/xyzwriter.h"
 #include <stdio.h>
 #include <string>
-#include <votca/csg/xyzwriter.h>
 namespace votca {
 namespace csg {
 

--- a/src/libcsg/molecule.cc
+++ b/src/libcsg/molecule.cc
@@ -15,8 +15,8 @@
  *
  */
 
+#include "../../include/votca/csg/molecule.h"
 #include <iostream>
-#include <votca/csg/molecule.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/nblist.cc
+++ b/src/libcsg/nblist.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/nblist.h"
+#include "../../include/votca/csg/topology.h"
 #include <iostream>
-#include <votca/csg/nblist.h>
-#include <votca/csg/topology.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/nblist_3body.cc
+++ b/src/libcsg/nblist_3body.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/nblist_3body.h"
+#include "../../include/votca/csg/topology.h"
 #include <iostream>
-#include <votca/csg/nblist_3body.h>
-#include <votca/csg/topology.h>
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/nblistgrid.cc
+++ b/src/libcsg/nblistgrid.cc
@@ -15,8 +15,8 @@
  *
  */
 
-#include <votca/csg/nblistgrid.h>
-#include <votca/csg/topology.h>
+#include "../../include/votca/csg/nblistgrid.h"
+#include "../../include/votca/csg/topology.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/nblistgrid_3body.cc
+++ b/src/libcsg/nblistgrid_3body.cc
@@ -15,8 +15,8 @@
  *
  */
 
-#include <votca/csg/nblistgrid_3body.h>
-#include <votca/csg/topology.h>
+#include "../../include/votca/csg/nblistgrid_3body.h"
+#include "../../include/votca/csg/topology.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/nematicorder.cc
+++ b/src/libcsg/nematicorder.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/nematicorder.h>
+#include "../../include/votca/csg/nematicorder.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/openbox.cc
+++ b/src/libcsg/openbox.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/openbox.h>
+#include "../../include/votca/csg/openbox.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/orthorhombicbox.cc
+++ b/src/libcsg/orthorhombicbox.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/orthorhombicbox.h>
+#include "../../include/votca/csg/orthorhombicbox.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/potentialfunctions/potentialfunction.cc
+++ b/src/libcsg/potentialfunctions/potentialfunction.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/potentialfunctions/potentialfunction.h>
+#include "../../../include/votca/csg/potentialfunctions/potentialfunction.h"
 #include <votca/tools/table.h>
 
 #include <boost/lexical_cast.hpp>

--- a/src/libcsg/potentialfunctions/potentialfunctioncbspl.cc
+++ b/src/libcsg/potentialfunctions/potentialfunctioncbspl.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../../include/votca/csg/potentialfunctions/potentialfunctioncbspl.h"
 #include <boost/lexical_cast.hpp>
 #include <iostream>
-#include <votca/csg/potentialfunctions/potentialfunctioncbspl.h>
 #include <votca/tools/table.h>
 
 using namespace std;

--- a/src/libcsg/potentialfunctions/potentialfunctionlj126.cc
+++ b/src/libcsg/potentialfunctions/potentialfunctionlj126.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/potentialfunctions/potentialfunctionlj126.h>
+#include "../../../include/votca/csg/potentialfunctions/potentialfunctionlj126.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/potentialfunctions/potentialfunctionljg.cc
+++ b/src/libcsg/potentialfunctions/potentialfunctionljg.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/potentialfunctions/potentialfunctionljg.h>
+#include "../../../include/votca/csg/potentialfunctions/potentialfunctionljg.h"
 
 using namespace std;
 

--- a/src/libcsg/topology.cc
+++ b/src/libcsg/topology.cc
@@ -15,16 +15,16 @@
  *
  */
 
+#include "../../include/votca/csg/topology.h"
+#include "../../include/votca/csg/boundarycondition.h"
+#include "../../include/votca/csg/interaction.h"
+#include "../../include/votca/csg/molecule.h"
+#include "../../include/votca/csg/openbox.h"
 #include <boost/lexical_cast.hpp>
 #include <cassert>
 #include <regex>
 #include <stdexcept>
 #include <unordered_set>
-#include <votca/csg/boundarycondition.h>
-#include <votca/csg/interaction.h>
-#include <votca/csg/molecule.h>
-#include <votca/csg/openbox.h>
-#include <votca/csg/topology.h>
 #include <votca/tools/rangeparser.h>
 
 namespace votca {

--- a/src/libcsg/topologymap.cc
+++ b/src/libcsg/topologymap.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/topologymap.h>
+#include "../../include/votca/csg/topologymap.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/topologyreader.cc
+++ b/src/libcsg/topologyreader.cc
@@ -19,12 +19,12 @@
 #include <votca_config.h>
 #endif
 
+#include "../../include/votca/csg/topologyreader.h"
+#include "../../include/votca/csg/xyzreader.h"
 #include "modules/io/groreader.h"
 #include "modules/io/lammpsdatareader.h"
 #include "modules/io/lammpsdumpreader.h"
 #include "modules/io/xmltopologyreader.h"
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/xyzreader.h>
 #ifdef GMX_DOUBLE
 #include "modules/io/gmxtopologyreader.h"
 #endif

--- a/src/libcsg/trajectoryreader.cc
+++ b/src/libcsg/trajectoryreader.cc
@@ -19,10 +19,10 @@
 #include <votca_config.h>
 #endif
 
+#include "../../include/votca/csg/trajectoryreader.h"
+#include "../../include/votca/csg/xyzreader.h"
 #include "modules/io/lammpsdatareader.h"
 #include "modules/io/lammpsdumpreader.h"
-#include <votca/csg/trajectoryreader.h>
-#include <votca/csg/xyzreader.h>
 
 #ifdef GMX_DOUBLE
 #include "modules/io/gmxtrajectoryreader.h"

--- a/src/libcsg/trajectorywriter.cc
+++ b/src/libcsg/trajectorywriter.cc
@@ -19,12 +19,12 @@
 #include <votca_config.h>
 #endif
 
+#include "../../include/votca/csg/pdbwriter.h"
+#include "../../include/votca/csg/trajectorywriter.h"
+#include "../../include/votca/csg/xyzwriter.h"
 #include "modules/io/dlpolytrajectorywriter.h"
 #include "modules/io/lammpsdumpwriter.h"
 #include <iostream>
-#include <votca/csg/pdbwriter.h>
-#include <votca/csg/trajectorywriter.h>
-#include <votca/csg/xyzwriter.h>
 
 #ifdef GMX_DOUBLE
 #include "modules/io/gmxtrajectorywriter.h"

--- a/src/libcsg/triclinicbox.cc
+++ b/src/libcsg/triclinicbox.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/triclinicbox.h>
+#include "../../include/votca/csg/triclinicbox.h"
 
 namespace votca {
 namespace csg {

--- a/src/libcsg/version.cc
+++ b/src/libcsg/version.cc
@@ -15,8 +15,8 @@
  *
  */
 
+#include "../../include/votca/csg/version.h"
 #include <iostream>
-#include <votca/csg/version.h>
 #include <votca/tools/version.h>
 #include <votca_config.h>
 

--- a/src/tests/test_basebead.cc
+++ b/src/tests/test_basebead.cc
@@ -18,13 +18,13 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE basebead_test
+#include "../../include/votca/csg/basebead.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/molecule.h"
+#include "../../include/votca/csg/topology.h"
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 #include <string>
-#include <votca/csg/basebead.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/molecule.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_bead.cc
+++ b/src/tests/test_bead.cc
@@ -18,13 +18,13 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE bead_test
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/molecule.h"
+#include "../../include/votca/csg/topology.h"
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/molecule.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_beadmotif_algorithms.cc
+++ b/src/tests/test_beadmotif_algorithms.cc
@@ -18,12 +18,12 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE beadmotifalgorithms_test
+#include "../../include/votca/csg/basebead.h"
+#include "../../include/votca/csg/beadmotif.h"            // IWYU pragma: keep
+#include "../../include/votca/csg/beadmotifalgorithms.h"  // IWYU pragma: keep
+#include "../../include/votca/csg/beadmotifconnector.h"
+#include "../../include/votca/csg/beadstructure.h"  // IWYU pragma: keep
 #include <boost/test/unit_test.hpp>
-#include <votca/csg/basebead.h>
-#include <votca/csg/beadmotif.h>            // IWYU pragma: keep
-#include <votca/csg/beadmotifalgorithms.h>  // IWYU pragma: keep
-#include <votca/csg/beadmotifconnector.h>
-#include <votca/csg/beadstructure.h>  // IWYU pragma: keep
 #include <votca/tools/edge.h>
 
 using namespace std;

--- a/src/tests/test_beadmotif_base.cc
+++ b/src/tests/test_beadmotif_base.cc
@@ -20,9 +20,9 @@
 #define BOOST_TEST_MODULE beadmotif_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/basebead.h"
+#include "../../include/votca/csg/beadmotif.h"
 #include <string>
-#include <votca/csg/basebead.h>
-#include <votca/csg/beadmotif.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_beadmotif_connector.cc
+++ b/src/tests/test_beadmotif_connector.cc
@@ -20,7 +20,7 @@
 #define BOOST_TEST_MODULE beadmotifconnector_test
 #include <boost/test/unit_test.hpp>
 
-#include <votca/csg/beadmotifconnector.h>
+#include "../../include/votca/csg/beadmotifconnector.h"
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_beadstructure_base.cc
+++ b/src/tests/test_beadstructure_base.cc
@@ -18,10 +18,10 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE beadstructure_test
+#include "../../include/votca/csg/basebead.h"
+#include "../../include/votca/csg/beadstructure.h"  // IWYU pragma: keep
 #include <boost/test/unit_test.hpp>
 #include <stdexcept>
-#include <votca/csg/basebead.h>
-#include <votca/csg/beadstructure.h>  // IWYU pragma: keep
 #include <votca/tools/types.h>
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_beadtriple.cc
+++ b/src/tests/test_beadtriple.cc
@@ -20,12 +20,12 @@
 #define BOOST_TEST_MODULE beadtriple_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadtriple.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/topology.h"
 #include <string>
 #include <tuple>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadtriple.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_interaction.cc
+++ b/src/tests/test_interaction.cc
@@ -20,12 +20,12 @@
 #define BOOST_TEST_MODULE interaction_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/interaction.h"
+#include "../../include/votca/csg/molecule.h"
+#include "../../include/votca/csg/topology.h"
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/interaction.h>
-#include <votca/csg/molecule.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_lammpsdatareader.cc
+++ b/src/tests/test_lammpsdatareader.cc
@@ -20,15 +20,15 @@
 #define BOOST_TEST_MODULE lammpdatatopologyreaderwriter_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/orthorhombicbox.h"
+#include "../../include/votca/csg/topologyreader.h"
+#include "../../include/votca/csg/trajectoryreader.h"
+#include "../../include/votca/csg/trajectorywriter.h"
 #include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/orthorhombicbox.h>
-#include <votca/csg/topologyreader.h>
-#include <votca/csg/trajectoryreader.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/elements.h>
 #include <votca/tools/types.h>
 

--- a/src/tests/test_lammpsdumpreaderwriter.cc
+++ b/src/tests/test_lammpsdumpreaderwriter.cc
@@ -20,14 +20,14 @@
 #define BOOST_TEST_MODULE lammpdumpstrajectoryreaderwriter_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/orthorhombicbox.h"
+#include "../../include/votca/csg/trajectoryreader.h"
+#include "../../include/votca/csg/trajectorywriter.h"
 #include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/orthorhombicbox.h>
-#include <votca/csg/trajectoryreader.h>
-#include <votca/csg/trajectorywriter.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/elements.h>
 #include <votca/tools/types.h>

--- a/src/tests/test_nblist_3body.cc
+++ b/src/tests/test_nblist_3body.cc
@@ -20,13 +20,13 @@
 #define BOOST_TEST_MODULE nblist_3body_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadlist.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/nblist_3body.h"
+#include "../../include/votca/csg/topology.h"
 #include <string>
 #include <vector>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadlist.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/nblist_3body.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_nblistgrid_3body.cc
+++ b/src/tests/test_nblistgrid_3body.cc
@@ -20,13 +20,13 @@
 #define BOOST_TEST_MODULE nblist_3body_test
 #include <boost/test/unit_test.hpp>
 
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadlist.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/nblistgrid_3body.h"
+#include "../../include/votca/csg/topology.h"
 #include <string>
 #include <vector>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadlist.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/nblistgrid_3body.h>
-#include <votca/csg/topology.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tests/test_pdbreader.cc
+++ b/src/tests/test_pdbreader.cc
@@ -18,13 +18,13 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE pdbreader_test
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/topologyreader.h"
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 #include <cmath>
 #include <fstream>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/topologyreader.h>
 #include <votca/tools/elements.h>
 
 using namespace std;

--- a/src/tests/test_triplelist.cc
+++ b/src/tests/test_triplelist.cc
@@ -18,14 +18,14 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE triplelist_test
+#include "../../include/votca/csg/bead.h"
+#include "../../include/votca/csg/beadtriple.h"
+#include "../../include/votca/csg/beadtype.h"
+#include "../../include/votca/csg/topology.h"
+#include "../../include/votca/csg/triplelist.h"
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 #include <string>
-#include <votca/csg/bead.h>
-#include <votca/csg/beadtriple.h>
-#include <votca/csg/beadtype.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/triplelist.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tools/csg_density.cc
+++ b/src/tools/csg_density.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <votca/csg/csgapplication.h>
+#include "../../include/votca/csg/csgapplication.h"
 #include <votca/tools/constants.h>
 #include <votca/tools/histogramnew.h>
 #include <votca/tools/tokenizer.h>

--- a/src/tools/csg_dlptopol.cc
+++ b/src/tools/csg_dlptopol.cc
@@ -15,10 +15,10 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
 #include <boost/format.hpp>
 #include <fstream>
 #include <iostream>
-#include <votca/csg/csgapplication.h>
 
 using namespace votca::csg;
 using namespace std;

--- a/src/tools/csg_dump.cc
+++ b/src/tools/csg_dump.cc
@@ -15,8 +15,8 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
 #include <stdlib.h>
-#include <votca/csg/csgapplication.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tools/csg_fmatch.cc
+++ b/src/tools/csg_fmatch.cc
@@ -16,14 +16,14 @@
  */
 
 #include "csg_fmatch.h"
+#include "../../include/votca/csg/beadlist.h"
+#include "../../include/votca/csg/nblistgrid.h"
+#include "../../include/votca/csg/nblistgrid_3body.h"
 #include <fstream>
 #include <iostream>
 #include <math.h>
 #include <sstream>
 #include <stdio.h>
-#include <votca/csg/beadlist.h>
-#include <votca/csg/nblistgrid.h>
-#include <votca/csg/nblistgrid_3body.h>
 #include <votca/tools/cubicspline.h>
 #include <votca/tools/linalg.h>
 #include <votca/tools/table.h>

--- a/src/tools/csg_fmatch.h
+++ b/src/tools/csg_fmatch.h
@@ -18,8 +18,8 @@
 #ifndef _VOTCA_CSG_FMATCH_H
 #define _VOTCA_CSG_FMATCH_H
 
-#include <votca/csg/csgapplication.h>
-#include <votca/csg/trajectoryreader.h>
+#include "../../include/votca/csg/csgapplication.h"
+#include "../../include/votca/csg/trajectoryreader.h"
 #include <votca/tools/cubicspline.h>
 #include <votca/tools/property.h>
 

--- a/src/tools/csg_gmxtopol.cc
+++ b/src/tools/csg_gmxtopol.cc
@@ -15,10 +15,10 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
 #include <boost/format.hpp>
 #include <fstream>
 #include <iostream>
-#include <votca/csg/csgapplication.h>
 
 using namespace votca::csg;
 using namespace std;

--- a/src/tools/csg_imc_solve.cc
+++ b/src/tools/csg_imc_solve.cc
@@ -16,8 +16,8 @@
  */
 
 #include "csg_imc_solve.h"
+#include "../../include/votca/csg/imcio.h"
 #include <fstream>
-#include <votca/csg/imcio.h>
 #include <votca/tools/table.h>
 
 int main(int argc, char** argv) {

--- a/src/tools/csg_imc_solve.h
+++ b/src/tools/csg_imc_solve.h
@@ -18,7 +18,7 @@
 #ifndef _VOTCA_CSG_IMC_SOLVE_H
 #define _VOTCA_CSG_IMC_SOLVE_H
 
-#include <votca/csg/version.h>
+#include "../../include/votca/csg/version.h"
 #include <votca/tools/application.h>
 #include <votca/tools/property.h>
 

--- a/src/tools/csg_map.cc
+++ b/src/tools/csg_map.cc
@@ -15,13 +15,13 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
+#include "../../include/votca/csg/topology.h"
+#include "../../include/votca/csg/trajectorywriter.h"
 #include <fstream>
 #include <stddef.h>
 #include <stdexcept>
 #include <string>
-#include <votca/csg/csgapplication.h>
-#include <votca/csg/topology.h>
-#include <votca/csg/trajectorywriter.h>
 
 using namespace std;
 using namespace votca::csg;

--- a/src/tools/csg_property.cc
+++ b/src/tools/csg_property.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/version.h"
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <votca/csg/version.h>
 #include <votca/tools/property.h>
 #include <votca/tools/tokenizer.h>
 

--- a/src/tools/csg_resample.cc
+++ b/src/tools/csg_resample.cc
@@ -15,9 +15,9 @@
  *
  */
 
+#include "../../include/votca/csg/version.h"
 #include <boost/program_options.hpp>
 #include <iostream>
-#include <votca/csg/version.h>
 #include <votca/tools/akimaspline.h>
 #include <votca/tools/cubicspline.h>
 #include <votca/tools/linspline.h>

--- a/src/tools/csg_reupdate.cc
+++ b/src/tools/csg_reupdate.cc
@@ -16,13 +16,13 @@
  */
 
 #include "csg_reupdate.h"
+#include "../../include/votca/csg/nblistgrid.h"
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <math.h>
 #include <sstream>
 #include <stdio.h>
-#include <votca/csg/nblistgrid.h>
 #include <votca/tools/constants.h>
 #include <votca/tools/linalg.h>
 /*

--- a/src/tools/csg_reupdate.h
+++ b/src/tools/csg_reupdate.h
@@ -17,13 +17,13 @@
 
 #ifndef _VOTCA_CSG_REUPDATE_H
 #define _VOTCA_CSG_REUPDATE_H
+#include "../../include/votca/csg/csgapplication.h"
+#include "../../include/votca/csg/potentialfunctions/potentialfunction.h"
+#include "../../include/votca/csg/potentialfunctions/potentialfunctioncbspl.h"
+#include "../../include/votca/csg/potentialfunctions/potentialfunctionlj126.h"
+#include "../../include/votca/csg/potentialfunctions/potentialfunctionljg.h"
+#include "../../include/votca/csg/topologyreader.h"
 #include <boost/program_options.hpp>
-#include <votca/csg/csgapplication.h>
-#include <votca/csg/potentialfunctions/potentialfunction.h>
-#include <votca/csg/potentialfunctions/potentialfunctioncbspl.h>
-#include <votca/csg/potentialfunctions/potentialfunctionlj126.h>
-#include <votca/csg/potentialfunctions/potentialfunctionljg.h>
-#include <votca/csg/topologyreader.h>
 #include <votca/tools/histogramnew.h>
 #include <votca/tools/property.h>
 #include <votca/tools/table.h>

--- a/src/tools/csg_stat.cc
+++ b/src/tools/csg_stat.cc
@@ -15,13 +15,13 @@
  *
  */
 
+#include "../../include/votca/csg/csgapplication.h"
+#include "../../include/votca/csg/version.h"
 #include "csg_stat_imc.h"
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
-#include <votca/csg/csgapplication.h>
-#include <votca/csg/version.h>
 
 // using namespace votca::tools;
 using namespace std;

--- a/src/tools/csg_stat_imc.cc
+++ b/src/tools/csg_stat_imc.cc
@@ -16,15 +16,15 @@
  */
 
 #include "csg_stat_imc.h"
+#include "../../include/votca/csg/beadlist.h"
+#include "../../include/votca/csg/imcio.h"
+#include "../../include/votca/csg/nblistgrid.h"
+#include "../../include/votca/csg/nblistgrid_3body.h"
 #include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
-#include <votca/csg/beadlist.h>
-#include <votca/csg/imcio.h>
-#include <votca/csg/nblistgrid.h>
-#include <votca/csg/nblistgrid_3body.h>
 #include <votca/tools/rangeparser.h>
 
 namespace votca {

--- a/src/tools/csg_stat_imc.h
+++ b/src/tools/csg_stat_imc.h
@@ -18,7 +18,7 @@
 #ifndef _VOTCA_CSG_IMC_H
 #define _VOTCA_CSG_IMC_H
 
-#include <votca/csg/csgapplication.h>
+#include "../../include/votca/csg/csgapplication.h"
 #include <votca/tools/average.h>
 #include <votca/tools/histogramnew.h>
 #include <votca/tools/property.h>


### PR DESCRIPTION
Changed system includes to local includes, this prevents issues that occur during compile time. E.g. if a header file is deleted in a new pull request but the header file is included in some of the source files in the pull request. In such a case, no errors will be seen if tested locally as the compiler will still find the file in the system includes. By building with what is in the local repo you avoid false positive builds. 