### PR TITLE
cma_processor.py: add support for cma-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 For more detailed information about the changes see the history of the
 [repository](https://github.com/votca/csg/commits/master).
 
+## Version 1.6.1 (released XX.04.20)
+* add support for cma-3 (#158) 
+
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)
 * enforce periodic boundaries for dihedrals (#500)
 * add warning about dihedrals (#500)

--- a/share/scripts/inverse/cma_processor.py
+++ b/share/scripts/inverse/cma_processor.py
@@ -16,7 +16,7 @@
 #
 
 
-from optparse import OptionParser
+import argparse
 import sys
 import re
 import pickle
@@ -89,10 +89,11 @@ except:
 
 
 usage = "usage: %prog [options] statefile-in statefile-out"
-parser = OptionParser(usage=usage)
-parser.add_option("--eps", dest="eps", metavar="EPS",
+parser = argparse.ArgumentParser(description=usage)
+
+parser.add_argument("--eps", dest="eps", metavar="EPS", type=float,
                   help="tolerance for initialization", default=0.1)
-(options, args) = parser.parse_args()
+(options, args) = parser.parse_known_args()
 
 if len(args) != 2:
     sys.exit("two statefile required as parameters")


### PR DESCRIPTION
cma-3 expect eps parameter to be a float, so added type=float. Also
replace obsolete optparse by argparse.