### PR TITLE
Bring back gmx-2018 support for Ubuntu 18.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For more detailed information about the changes see the history of the
 * add support for cma-3 (#158) 
 * allow special characters in build directory (#521) 
 * fix CI on Ubuntu-20.04 (#526)
-* drop support for gmx 2016/2018 (#529)
+* drop support for gmx 2016 (#529, #547)
 * fix csg_reupdate and add tests (#525)
 * fix detection of lmp and gmx in cmake (#540)
 * add test for lammpsdata reader (#544)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ option(WITH_GMX "Build gromacs reader/writer, disabling leads to reduced functio
 if (WITH_GMX)
   find_package(GROMACS 2021 QUIET CONFIG NAMES gromacs gromacs_d)
   if(NOT GROMACS_FOUND)
-    find_package(GROMACS 2019 REQUIRED MODULE)
+    find_package(GROMACS 2018 REQUIRED MODULE)
   endif()
   if(DEFINED GROMACS_VERSION AND GROMACS_VERSION VERSION_GREATER_EQUAL "2020")
     message(WARNING "Gromacs-2020 and above have no support for tabulated interactions, that are needed for coarse-graining (see and comment on https://gitlab.com/gromacs/gromacs/-/issues/1347)")

--- a/share/scripts/inverse/run_gromacs.sh
+++ b/share/scripts/inverse/run_gromacs.sh
@@ -31,6 +31,10 @@ fi
 tpr="$(csg_get_property cg.inverse.gromacs.topol)"
 
 mdrun_opts="$(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.opts)"
+# remove this block when dropping support for gmx-2018
+if [[ ${mdrun_opts} = *"-multi "* ]]; then
+  die "${0##*/}: Support for '-multi' got removed in gromacs-2019, please use multidir (through cg.inverse.gromacs.mdrun.multidir) option instead"
+fi
 
 multidir=( $(csg_get_property --allow-empty cg.inverse.gromacs.mdrun.multidir) )
 

--- a/src/libcsg/modules/io/gmxtopologyreader.cc
+++ b/src/libcsg/modules/io/gmxtopologyreader.cc
@@ -54,7 +54,11 @@ bool GMXTopologyReader::ReadTopology(std::string file, Topology &top) {
 
   size_t ifirstatom = 0;
 
+#if GMX_VERSION >= 20190000
   size_t nmolblock = mtop.molblock.size();
+#else
+  size_t nmolblock = mtop.nmolblock;
+#endif
 
   for (size_t iblock = 0; iblock < nmolblock; ++iblock) {
     gmx_moltype_t *mol = &(mtop.moltype[mtop.molblock[iblock].type]);
@@ -72,7 +76,11 @@ bool GMXTopologyReader::ReadTopology(std::string file, Topology &top) {
     for (Index imol = 0; imol < mtop.molblock[iblock].nmol; ++imol) {
       Molecule *mi = top.CreateMolecule(molname);
 
+#if GMX_VERSION >= 20190000
       size_t natoms_mol = mtop.moltype[mtop.molblock[iblock].type].atoms.nr;
+#else
+      size_t natoms_mol = mtop.molblock[iblock].natoms_mol;
+#endif
       // read the atoms
       for (size_t iatom = 0; iatom < natoms_mol; iatom++) {
         t_atom *a = &(atoms->atom[iatom]);


### PR DESCRIPTION
Partially revert "drop support for gmx 2016/2018" (#529)

This reverts commit a4edeaa81da864ce3a6c6a566e366c648693ebf2.
Bring back gmx-2018 support for Ubuntu 18.04