### PR TITLE
run_gromacs.sh: fix warning about gmx-2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ For more detailed information about the changes see the history of the
 
 ## Version 1.6.3 (released XX.08.20)
 * fix test dependencies for parallel ctest (#585)
+* fix trigger for gmx-2020 warning in run_gromacs.sh (#591)
 
 ## Version 1.6.2 _SuperGitta_ (released 22.08.20)
 * move CI to GitHub Actions (#563, #567, #569)

--- a/share/scripts/inverse/run_gromacs.sh
+++ b/share/scripts/inverse/run_gromacs.sh
@@ -62,7 +62,7 @@ grompp=( $(csg_get_property cg.inverse.gromacs.grompp.bin) )
 [[ -n "$(type -p ${grompp[0]})" ]] || die "${0##*/}: grompp binary '${grompp[0]}' not found"
 
 gmx_ver="$(critical ${grompp[@]} -h 2>&1)"
-[[ ${gmx_ver} = *"VERSION 2020"* ]] && die "GROMACS 2020 doesn't support tabulated interactions, that are needed for coarse-graining (see and comment on https://redmine.gromacs.org/issues/1347). Please use GROMACS 2019 for now."
+[[ ${gmx_ver} = *"version 2020"* ]] && die "GROMACS 2020 doesn't support tabulated interactions, that are needed for coarse-graining (see and comment on https://redmine.gromacs.org/issues/1347). Please use GROMACS 2019 for now."
 
 traj=$(csg_get_property cg.inverse.gromacs.traj)
 # in main simulation we usually do care about traj and temperature


### PR DESCRIPTION
The pattern wasn't correct hence the message never got triggered, discovered in #590.