### PR TITLE
csg_inverse: improve error message for broken binaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Version 2021-dev
 -  add periodic extrapolation for dihedrals (#576)
 -  bump required CMake version to 3.12 (#599)
 -  Fixed boost test deprecation warnings (#598)
+-  improve error message for broken binaries (#601)
 
 Version 1.6.3 (released XX.08.20)
 =================================

--- a/share/scripts/inverse/start_framework.sh
+++ b/share/scripts/inverse/start_framework.sh
@@ -39,6 +39,9 @@ export CSG_MASTER_PID="$$"
 
 export CSG_MAINDIR="$PWD"
 
+[[ -n $(type -p csg_property) ]] || die "csg_property not found"
+csg_property --help > /dev/null || die "Could not run 'csg_property --help'\nRun it by hand to debug the problem!"
+
 if [[ -n ${VOTCA_CSG_DEFAULTS} ]]; then
   [[ -f ${VOTCA_CSG_DEFAULTS} ]] || die "Could not find ${VOTCA_CSG_DEFAULTS}! Is VOTCA_CSG_DEFAULTS set corectly?"
 else


### PR DESCRIPTION
Fix #600 

@marvinbernhardt can you check if this error message gets trigger (and is helpful) in our original build from #600.