### PR TITLE
GHA: remove set-env calls

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,15 +28,16 @@ jobs:
           prerelease: ${{ contains(github.ref, 'rc') }}
           body_path: 'release_changelog.md'
       - name: Get version
-        run: echo "::set-env name=VERSION::${GITHUB_REF#refs/tags/v}"
+        id: version
+        run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/v}"
       - name: Get manual
-        run: wget https://github.com/votca/votca/releases/download/v${{ env.VERSION }}/votca-csg-manual-${{ env.VERSION }}.pdf
+        run: wget https://github.com/votca/votca/releases/download/v${{ steps.version.outputs.VERSION }}/votca-csg-manual-${{ steps.version.outputs.VERSION }}.pdf
       - name: Upload manual
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.VOTCA_BOT_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./votca-csg-manual-${{ env.VERSION }}.pdf
-          asset_name: votca-csg-manual-${{ env.VERSION }}.pdf
+          asset_path: ./votca-csg-manual-${{ steps.version.outputs.VERSION }}.pdf
+          asset_name: votca-csg-manual-${{ steps.version.outputs.VERSION }}.pdf
           asset_content_type: application/pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For more detailed information about the changes see the history of the
 * switch to ghcr.io for CI (#595)
 * format code with clang-11 (#605)
 * add gmx2021 builds to CI (#607)
+* remove set-env call from CI (#608)
 
 ## Version 1.6.2 _SuperGitta_ (released 22.08.20)
 * move CI to GitHub Actions (#563, #567, #569)


### PR DESCRIPTION
see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/