### PR TITLE
Get rid of boost warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 2022-dev
 -  switch NBList to unique_ptr (#659)
 -  switch csgapplication worker to unique_ptr (#660)
 -  remove use of new with splines in csg_fmatch (#662)
+-  update boost test floating point comparison header (#663)
 
 Version 2021-rc.2 (released XX.01.21)
 =====================================

--- a/src/tests/test_pdbreader.cc
+++ b/src/tests/test_pdbreader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2021 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #define BOOST_TEST_MODULE pdbreader_test
 #include "../../include/votca/csg/bead.h"
 #include "../../include/votca/csg/topologyreader.h"
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 #include <cmath>
 #include <fstream>


### PR DESCRIPTION
Update the header, the old one is now deprecated. 