### PR TITLE
Fix the ref syntax in csg-manual

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Version 2022-dev
 -  convert maps to unique_ptrs (#653)
 -  add iterative integral equation (iie) method (#675)
 -  fix issues with IHNC (newton-mod) Integral equation method (#683)
--  fix links in documentation (#686)
+-  fix links in documentation (#686, #687)
 
 Version 2021.1 (released XX.03.21)
 ==================================

--- a/share/doc/advanced_topics.rst
+++ b/share/doc/advanced_topics.rst
@@ -14,7 +14,7 @@ organized as follows: all scripts are called using two keywords
 
 For example, ``csg_call update imc`` calls the ``update`` script for the
 inverse Monte Carlo procedure. The corresponding keywords are listed in
-:ref: `_reference_scripts` or can be output directly by calling
+:ref:`reference_scripts` or can be output directly by calling
 
 .. code:: bash
 
@@ -57,7 +57,7 @@ The output should look as follows
       convert_potential gromacs potential_to_gromacs.sh
 
 the third line indicates the script we need. If the output of is not
-clear, one can try to find the right script in :ref: `_reference_scripts`.
+clear, one can try to find the right script in :ref:`reference_scripts`.
 Alternatively, check the folder
 
 .. code:: none
@@ -98,7 +98,7 @@ local path. Now we change the last line of ``my_run_gromacs.sh`` to:
       critical mpirun -np 8 mdrun
 
 This completes the customization. Do not forget to add ``SCRIPTDIR`` to
-in the setting XMLfile (see :ref: `_reference_settings_file`).
+in the setting XMLfile (see :ref:`reference_settings_file`).
 
 You can check the new script by running:
 
@@ -182,7 +182,7 @@ It is also possible to specify file names different from the standard
 DL\_POLY convention, in which case the user has to use the corresponding
 dot-preceded extension(s); for example: FA-FIELD.dlpf instead of FIELD
 or CG-HISTORY.dlph instead of HISTORY\_CGV (see
-:ref: `_reference_programs`, as well as the man pages or output of
+:ref:`reference_programs`, as well as the man pages or output of
 VOTCA commands, with option ``—help``).
 
 VOTCA follows the DL\_POLY conventions for file names and formats. Thus,
@@ -208,5 +208,5 @@ DL\_POLY-4 (4.06+).
 The user is advised to search for “dlpoly” through the
 ``csg_defaults.xml``, ``csg_table`` files and in scripts located in
 ``share/votca/scripts/inverse/`` in order to find out about the xml-tags
-and options specific for DL\_POLY; see also :ref: `_reference_settings_file`
-and :ref: `_reference_scripts`.
+and options specific for DL\_POLY; see also :ref:`reference_settings_file`
+and :ref:`reference_scripts`.

--- a/share/doc/input_files.rst
+++ b/share/doc/input_files.rst
@@ -29,7 +29,7 @@ positions of atoms which belong to it. Note that :math:`c_{Ii}` will be
 automatically re-normalized if their sum is not equal to 1, i. e. in the
 case of a center-of-mass mapping one can simply specify atomic masses. A
 complete reference for mapping file definitions can be found in
-:ref: `_reference_mapping_file`.
+:ref:`reference_mapping_file`.
 
 As an example, we will describe here a mapping file of a united atom
 model of a propane molecule, chemical structure of which is shown in
@@ -63,7 +63,7 @@ the tool ``csg_dump`` can be used in order to identify the atoms which are read 
 from a topology file ``.tpr``. This tool displays the atoms in the
 format ``residue id:residue name:atom name``. For multicomponent
 systems, it might happen that molecules are not identified correctly.
-The workaround for this case is described in :ref: `_input_files_advanced_topology_handling`.
+The workaround for this case is described in :ref:`input_files_advanced_topology_handling`.
 
 To compare coarse-grained and atomistic configurations one can use a
 standard visualization program, e. g. ``vmd``. When comparing
@@ -245,7 +245,7 @@ The box size can be set by the tag ``box``:
 where ``xx, yy, zz`` are the dimensions of the box.
 
 A complete reference for a XML topology file can be found in
-:ref: `_reference_topology_file`.
+:ref:`reference_topology_file`.
 
 .. _input_files_trajectories:
 
@@ -339,7 +339,7 @@ potential) and ``[error]`` is an optional error for ``y``. The token
 ``u`` stands for an ``undefined`` value.
 
 The token ``flag`` will be important when extrapolating the table as
-described in :ref: `_preparing_post-processing_of_the_potential`.
+described in :ref:`preparing_post-processing_of_the_potential`.
 
 For historical reasons, ``csg_boltzmann`` uses a slightly different table format, it has
 no ``flag`` column and uses the third column as a force column when

--- a/share/doc/input_files.rst
+++ b/share/doc/input_files.rst
@@ -14,6 +14,8 @@ file is created. When used as a command option, these files are combined
 in a list separated by a semicolon, e. g.
 ``—cg`` ``protein.xml;solvent.xml``.
 
+.. _input_files_fig_mapping:
+
 .. figure:: fig/mapping.png
     :align: center
 
@@ -33,10 +35,10 @@ complete reference for mapping file definitions can be found in
 
 As an example, we will describe here a mapping file of a united atom
 model of a propane molecule, chemical structure of which is shown in
-fig. [fig:intro:propane]. In this coarse-grained model, two bead types
-(A,B) and three beads (A1, B1, A2) are defined, as shown in
-fig. [fig:propane\_map]. We will use the centers of mass of the beads as
-coarse-grained coordinates.
+:ref:`the figure in the introduction<introduction_fig_propane>`. In this
+coarse-grained model, two bead types (A,B) and three beads (A1, B1, A2) are
+defined, as shown in :ref:`the figure above<input_files_fig_mapping>`. We will
+use the centers of mass of the beads as coarse-grained coordinates.
 
 Extracts from the ``propane.xml`` file of the tutorial are shown below.
 The ``name`` tag indicates the molecule name in the coarse-grained topology. The

--- a/share/doc/introduction.rst
+++ b/share/doc/introduction.rst
@@ -25,6 +25,8 @@ the moment, an interface to GROMACS [gromacs4]_
 simulation package is provided. The rest of the analysis needed for
 systematic coarse-graining is done using the package tools.
 
+.. _introduction_fig_propane:
+
 .. figure:: fig/propane.png
     :align: center
 

--- a/share/doc/methods.rst
+++ b/share/doc/methods.rst
@@ -163,10 +163,10 @@ can be used. Its usage and options are very similar to the ``hist``
 command. If tabulated potentials are written, special care should be
 taken to the parameters ``T`` (temperature) and the ``scale``. The
 ``scale`` enables volume normalization as given in
-eq. [eq:boltzmann\_norm]. Possible values are ``no`` (no scaling),
-``bond`` (normalize bonds) and ``angle`` (normalize angles). To write
-out the tabulated potential for an angle potential at a temperature of
-300K, for instance, type:
+:ref:`the equations in the theory section<theory_eq_boltzmann_norm>`. Possible
+values are ``no`` (no scaling), ``bond`` (normalize bonds) and ``angle``
+(normalize angles). To write out the tabulated potential for an angle potential
+at a temperature of 300K, for instance, type:
 
 .. code:: none
 
@@ -183,10 +183,10 @@ command ``tab``, the potential is prepared for the coarse-grained run in
 Correlation analysis
 ~~~~~~~~~~~~~~~~~~~~
 
-The factorization of :math:`P` in eq. [eq:boltzmann\_pmf] assumed
-uncorrelated quantities. offers two ways to evaluate correlations of
-interactions. One option is to use the linear correlation coefficient
-(command ``cor``).
+The factorization of :math:`P`, :ref:`as shown in the theory
+section<theory_eq_boltzmann_pmf>`, assumed uncorrelated quantities. VOTCA
+offers two ways to evaluate correlations of interactions. One option is to use
+the linear correlation coefficient (command ``cor``).
 
 However, this is not a good measure since ``cor`` calculates the linear
 correlation only which might often lead to misleading

--- a/share/doc/methods.rst
+++ b/share/doc/methods.rst
@@ -612,7 +612,7 @@ General considerations
 In comparison to IBI, IMC needs significantly more statistics to
 calculate the potential update[Ruehle:2009.a]_. It is
 advisable to perform smoothing on the potential update. Smoothing can be
-performed as described in sec. [ref:ibi:optimize]. In addition, IMC can
+performed as described in :ref:`methods_runtime_optimizations`. In addition, IMC can
 lead to problems related to finite size: for methanol, an undersized
 system proved to lead to a linear shift in the
 potential[Ruehle:2009.a]_. It is therefore always
@@ -1000,6 +1000,8 @@ iteraction without doing potential update
 
 Here, is the scaling factor :math:`A`. is :math:`r_1` and is :math:`r_2`
 used to calculate the average of :math:`G_{ij}(R)`.
+
+.. `_methods_runtime_optimizations`
 
 Runtime optimization
 --------------------

--- a/share/doc/methods.rst
+++ b/share/doc/methods.rst
@@ -25,14 +25,14 @@ whole trajectory and stores all information on bonded interactions in
 memory, which is useful for interactive analysis. For big systems,
 however, one can run out of memory. In this case can be used which,
 however, has a limited number of tasks it can perform (see 
-:ref: `_input_files_setting_files` for an example on its usage).
+:ref:`input_files_setting_files` for an example on its usage).
 
 Another useful tool is . It can be used to convert an atomistic
 trajectory to a coarse-grained one, as it is discussed in
-:ref: `_input_files_trajectories`.
+:ref:`input_files_trajectories`.
 
 To use one has to first define a mapping scheme. This is outlined
-in :ref: `_input_files_mapping_files`. Once the mapping scheme is specified, it
+in :ref:`input_files_mapping_files`. Once the mapping scheme is specified, it
 is possible to generate an exclusion list for the proper sampling of the
 atomistic resolution system.
 
@@ -175,10 +175,10 @@ out the tabulated potential for an angle potential at a temperature of
       tab angle.pot *:angle:*
 
 The table is then written into the file ``angle.pot`` in the format
-described in :ref: `_input_files_table_formats`. An optional correlation analysis
+described in :ref:`input_files_table_formats`. An optional correlation analysis
 is described in the next section. After the file has been created by
 command ``tab``, the potential is prepared for the coarse-grained run in
-:ref: `_preparing`.
+:ref:`preparing`.
 
 Correlation analysis
 ~~~~~~~~~~~~~~~~~~~~
@@ -233,7 +233,7 @@ The tabulated potentials created in this section can be further modified
 and prepared for the coarse-grained run: This includes fitting of a
 smooth functional form, extrapolation and clipping of poorly sampled
 regions. Further processing of the potential is decribed in 
-:ref: `_preparing`.
+:ref:`preparing`.
 
 Force matching
 ==============
@@ -256,7 +256,7 @@ option in the GROMACS ``.mdp`` file), otherwise will not be able to
 run.
 
 In addition, a mapping scheme has to be created, which defines the
-coarse-grained model (see :ref: `_input_files`). At last, a control
+coarse-grained model (see :ref:`input_files`). At last, a control
 file has to be created, which contains all the information for
 coarse-graining the interactions and parameters for the force-matching
 run. This file is specified by the tag ``–options`` in the XMLformat. An
@@ -288,11 +288,11 @@ example might look like the following
     </non-bonded>
   </cg>
 
-Similarly to the case of spline fitting (see :ref: `_reference_programs` on
+Similarly to the case of spline fitting (see :ref:`reference_programs` on
 ), the parameters ``min`` and ``max`` have to be chosen in such a way as
 to avoid empty bins within the grid. Determining ``min`` and ``max`` by
-using is recommended (see :ref: `_input_files_setting_files`). A full description
-of all available options can be found in :ref: `_reference_settings_file`.
+using is recommended (see :ref:`input_files_setting_files`). A full description
+of all available options can be found in :ref:`reference_settings_file`.
 
 Program output
 --------------
@@ -330,7 +330,7 @@ potential to the ``.pot`` file.
 In general, each potential contains regions which are not sampled. In
 this case or in the case of further post-processing, the potential can
 be refined by employing resampling or extrapolating methods. See 
-:ref: `_preparing_post-processing_of_the_potential` for further details.
+:ref:`preparing_post-processing_of_the_potential` for further details.
 
 .. _methods_iterative_methods:
 
@@ -344,7 +344,7 @@ method, the Inverse Monte Carlo (IMC) method, the Iterative Integral Equation
 In general, IBI, IMC, IIE, and RE are implemented within the same framework.
 Therefore, most of the settings and parameters used by these methods are
 similar and thus described in a general section (see 
-:ref: `_methods_inverse_monte_carlo`). Further information on iterative methods
+:ref:`methods_inverse_monte_carlo`). Further information on iterative methods
 follows in the next chapters, in particular on the IBI, IMC, IIE, and RE
 methods.
 
@@ -402,7 +402,7 @@ Therefore, all files needed to run a coarse-grained simulation, except
 for the potentials that are iteratively refined, must be provided and
 added to the in the settings XML-file. If an atomistic topology and a
 mapping definition are present, VOTCA offers tools to assist the setup of
-a coarse-grained topology (see :ref: `_preparing`).
+a coarse-grained topology (see :ref:`preparing`).
 
 To get an overview of how input files look like, it is suggested to take
 a look at one of the tutorials provided on .
@@ -416,7 +416,7 @@ Preparing the run
 To start the first iteration, one has to prepare the input for the
 sampling program. This means that all files for running a coarse-grained
 simulation must be present and described in a separate XMLfile, in our
-case ``settings.xml`` (see :ref: `_input_files_setting_files` for details). An
+case ``settings.xml`` (see :ref:`input_files_setting_files` for details). An
 extract from this file is given below. The only exception are tabulated
 potentials, which will be created and updated by the script in the
 course of the iterative process.
@@ -438,7 +438,7 @@ you plan to run the iterative procedure.
 A list of interactions to be iteratively refined has to be given in the
 options file. As an example, the ``setting.xml`` file for a propane is
 shown in below. For more details, see the full
-description of all options in :ref: `_reference_settings_file`.
+description of all options in :ref:`reference_settings_file`.
 
 .. code:: xml
 
@@ -577,7 +577,7 @@ Input preparation
 
 This section describes the usage of IBI, implemented within the
 scripting framework described in
-:ref: `_methods_iterative_workflow`. It is suggested to get a basic
+:ref:`methods_iterative_workflow`. It is suggested to get a basic
 understanding of this framework before proceeding.
 
 An outline of the workflow for performing IBIis given in
@@ -767,7 +767,7 @@ Relative Entropy
 In this section, additional options are described to run RE coarse
 graining. The usage of RE is similar to that of IBI and IMC and
 understanding the use of the scripting framework described in
-:ref: `_methods_iterative_workflow` is necessary.
+:ref:`methods_iterative_workflow` is necessary.
 
 Currently, RE implementation supports optimization of two-body non-bonded
 pair interactions. Support for bonded and N-body interactions is

--- a/share/doc/methods.rst
+++ b/share/doc/methods.rst
@@ -341,39 +341,42 @@ The following sections deal with the Iterative Boltzmann Inversion (IBI)
 method, the Inverse Monte Carlo (IMC) method, the Iterative Integral Equation
 (IIE) method, and the Relative Entropy (RE) method.
 
-In general, IBI, IMC, IIE, and RE are implemented within the same framework.
-Therefore, most of the settings and parameters used by these methods are
-similar and thus described in a general section (see 
-:ref:`methods_inverse_monte_carlo`). Further information on iterative methods
-follows in the next chapters, in particular on the IBI, IMC, IIE, and RE
-methods.
+.. _methods_fig_flowchart_spanning:
 
 .. figure:: fig/iterative-methods.png
 
-   Flowchart to perform iterative Boltzmann inversion.
+   Flowchart of the spanning workflow of iterative methods.
+
+In general, IBI, IMC, IIE, and RE are implemented within the same framework.
+Therefore, most of the settings and parameters used by these methods are
+similar and thus described in a general section (see
+:ref:`methods_preparing_the_run`). Further information on iterative methods
+follows in the next chapters, in particular on the IBI, IMC, IIE, and RE
+methods.
 
 .. _methods_iterative_workflow:
 
 Iterative workflow control
 --------------------------
 
-.. figure:: fig/iteration-scheme.png
-
-   Block-scheme of the workflow control for the iterative
-   methods. The most time-consuming parts are marked in red.
-
 Iterative workflow control is essential for the IBI, IMC, IIE, and RE methods.
 
+.. _methods_fig_flowchart_iterative:
+
+.. figure:: fig/iteration-scheme.png
+
+   Forkflow control for the iterative methods. The most time-consuming parts
+   are marked in red.
+
 The general idea of iterative workflow is sketched in
-fig. [fig:flowchart]. During the global initialization the initial guess
-for the coarse-grained potential is calculated from the reference
-function or converted from a given potential guess into the internal
-format. The actual iterative step starts with an iteration
-initialization. It searches for possible checkpoints and copies and
-converts files from the previous step and the base directory. Then, the
-simulation run is prepared by converting potentials into the format
-required by the external sampling program and the actual sampling is
-performed.
+:ref:`the flowchart above<methods_fig_flowchart_iterative>`. During the global
+initialization the initial guess for the coarse-grained potential is calculated
+from the reference function or converted from a given potential guess into the
+internal format. The actual iterative step starts with an iteration
+initialization. It searches for possible checkpoints and copies and converts
+files from the previous step and the base directory. Then, the simulation run
+is prepared by converting potentials into the format required by the external
+sampling program and the actual sampling is performed.
 
 After sampling the phasespace, the potential update is calculated.
 Often, the update requires postprocessing, such as smoothing,
@@ -409,6 +412,8 @@ a look at one of the tutorials provided on .
 
 In what follows we describe how to set up the iterative coarse-graining,
 run the main script, continue the run, and add customized scripts.
+
+.. _methods_preparing_the_run:
 
 Preparing the run
 ~~~~~~~~~~~~~~~~~
@@ -575,13 +580,9 @@ Iterative Boltzmann Inversion
 Input preparation
 ~~~~~~~~~~~~~~~~~
 
-This section describes the usage of IBI, implemented within the
-scripting framework described in
-:ref:`methods_iterative_workflow`. It is suggested to get a basic
-understanding of this framework before proceeding.
-
-An outline of the workflow for performing IBIis given in
-fig. [fig:flow\_ibi].
+This section describes the usage of IBI, implemented within the scripting
+framework described in :ref:`methods_iterative_workflow`. It is suggested to
+get a basic understanding of this framework before proceeding.
 
 To specify Iterative Boltzmann Inversion as algorithm in the script, add
 ``ibi`` in the ``method`` section of the XMLsetting file as shown below.
@@ -1001,7 +1002,7 @@ iteraction without doing potential update
 Here, is the scaling factor :math:`A`. is :math:`r_1` and is :math:`r_2`
 used to calculate the average of :math:`G_{ij}(R)`.
 
-.. `_methods_runtime_optimizations`
+.. _methods_runtime_optimizations:
 
 Runtime optimization
 --------------------

--- a/share/doc/preparing.rst
+++ b/share/doc/preparing.rst
@@ -51,8 +51,8 @@ Post-processing of the potential
 The VOTCA package provides a collection of scripts to handle potentials.
 They can be modified, refined, integrated or inter- and extrapolated.
 These scripts are the same ones as those used for iterative methods in
-:ref: `_methods_iterative_methods`. Scripts are called by . A complete
-list of available scripts can be found in :ref: `_reference_scripts`.
+:ref:`methods_iterative_methods`. Scripts are called by . A complete
+list of available scripts can be found in :ref:`reference_scripts`.
 
 The post-processing roughly consists of the following steps (see further
 explanations below):

--- a/share/doc/theory.rst
+++ b/share/doc/theory.rst
@@ -105,6 +105,8 @@ The idea of Boltzmann inversion stems from the fact that in a canonical
 ensemble *independent* degrees of freedom :math:`q` obey the Boltzmann
 distribution, i. e.
 
+
+
 .. math::
 
    P(q) = Z^{-1} \exp\left[ - \beta U(q) \right]~,
@@ -130,6 +132,8 @@ Note that the histograms for the bonds :math:`H_r(r)`, angles
 have to be rescaled in order to obtain the volume normalized
 distribution functions :math:`P_r(r)`, :math:`P_\theta(\theta)`, and
 :math:`P_\varphi(\varphi)`, respectively,
+
+A
 
 .. math::
 
@@ -201,23 +205,24 @@ This can be done by employing exclusion lists using with the option
 Iterative methods
 -----------------
 
+.. _theory_fig_iterative_simple:
+
 .. figure:: fig/iteration-scheme-simple.png
    :align: center
 
    Block-scheme of an iterative method.
 
-Iterative workflow control is essential for the IBIand IMCmethods. The
+Iterative workflow control is essential for the IBI and IMC methods. The
 general idea of iterative workflow is sketched in
-fig. [fig:iterative\_methods]. A run starts with an initial guess during
-the global initialization phase. This guess is used for the first
-sampling step, followed by an update of the potential. The update itself
-often requires additional postprocessing such as smoothing,
-interpolation, extrapolation or fitting. Different methods are available
-to update the potential, for instance Iterative Boltzmann Inversion (see
-:ref:`theory_iterative_boltzmann_inversion`) or Inverse Monte Carlo
-(see :ref:`theory_inverse_monte_carlo`).
-The whole procedure is then iterated until a convergence criterion is
-satisfied.
+:ref:`the block-scheme above<theory_fig_iterative_simple>`. A run starts with
+an initial guess during the global initialization phase. This guess is used for
+the first sampling step, followed by an update of the potential. The update
+itself often requires additional postprocessing such as smoothing,
+interpolation, extrapolation or fitting. Different methods are available to
+update the potential, for instance Iterative Boltzmann Inversion (see
+:ref:`theory_iterative_boltzmann_inversion`) or Inverse Monte Carlo (see
+:ref:`theory_inverse_monte_carlo`). The whole procedure is then iterated until
+a convergence criterion is satisfied.
 
 .. _theory_iterative_boltzmann_inversion:
 

--- a/share/doc/theory.rst
+++ b/share/doc/theory.rst
@@ -35,6 +35,8 @@ case letters are used for the atomistic system.
 The mapping operator :math:`{\mathbf c}_I` is defined by a matrix for each
 bead :math:`I` and links the two descriptions
 
+.. _theory_eq_mapping_scheme:
+
 .. math::
 
    \begin{aligned}
@@ -44,7 +46,6 @@ bead :math:`I` and links the two descriptions
        M_I \sum_{i=1}^{n}c_{Ii} \dot{{\mathbf r}}_i =
        M_I \sum_{i=1}^{n} \frac{ c_{Ii}} {m_i} {\mathbf p}_i .
    \end{aligned}
-   \label{eq:mapping_scheme}
 
 for all :math:`I = 1,\dots,N`.
 
@@ -65,7 +66,7 @@ each of the :math:`N` CG beads. For each site :math:`I`, a set of
 
 An atom :math:`i` in the atomistic model is involved in a CG site, *I*,
 if and only if this atom provides a nonzero contribution to the sum in
-eq. [eq:mapping\_scheme].
+:ref:`the equation above<theory_eq_mapping_scheme>`.
 
 A set of *specific* atoms is defined as
 
@@ -83,11 +84,10 @@ by [Noid:2008.1]_
 .. math::
 
    M_I= \left( \sum_{i \in {\cal I}_I}\frac{c_{Ii}^2}{m_i} \right)^{-1}.
-   \label{eq:cg_mass}
 
 If all atoms are specific and the center of mass of a bead is used for
 mapping, then :math:`c_{Ii} = \frac{m_i}{M_I}`, and the
-condition [eq:cg\_mass] is automatically satisfied.
+condition is automatically satisfied.
 
 .. rubric:: Footnotes
 .. [#] In what follows we adopt notations of ref. [Noid:2008.1]_.
@@ -133,7 +133,7 @@ have to be rescaled in order to obtain the volume normalized
 distribution functions :math:`P_r(r)`, :math:`P_\theta(\theta)`, and
 :math:`P_\varphi(\varphi)`, respectively,
 
-A
+.. _theory_eq_boltzmann_norm:
 
 .. math::
 
@@ -142,17 +142,17 @@ A
    P_\theta(\theta) = \frac{H_\theta(\theta)}{\sin \theta}~,\;
    P_\varphi(\varphi) = H_\varphi (\varphi)~,
    \end{aligned}
-   \label{eq:boltzmann_norm}
 
 where :math:`r` is the bond length :math:`r`, :math:`\theta` is the
 bond angle, and :math:`\varphi` is the torsion angle. The bonded
 coarse-grained potential can then be written as a sum of distribution
 functions
 
+.. _theory_eq_boltzmann_pmf:
+
 .. math::
 
    \begin{aligned}
-       \label{eq:boltzmann_pmf}
        U({r}, \theta, \varphi) &= U_r({r}) + U_{\theta}(\theta) + U_{\varphi}(\varphi)~, \\
        U_q({q}) &= - k_\text{B} T \ln P_q( q ),\; q=r, \theta, \varphi~.
        \nonumber\end{aligned}
@@ -168,7 +168,7 @@ important.
 Another crucial issue is the cross-correlation of the coarse-grained
 degrees of freedom. Independence of the coarse-grained degrees of
 freedom is the main assumption that allows factorization of the
-probability distribution and the potential, eq. [eq:boltzmann\_pmf].
+probability distribution and the potential :ref:`as in the above equation<theory_eq_boltzmann_pmf>`.
 Hence, one has to carefully check whether this assumption holds in
 practice. This can be done by performing coarse-grained simulations and
 comparing cross-correlations for all pairs of degrees of freedom in
@@ -283,10 +283,11 @@ solving a set of linear equations
 
 where
 
+.. _theory_eq_covariance:
+
 .. math::
 
    \begin{aligned}
-     \label{eq:covariance}
      A_{\alpha \gamma} = \frac{\partial \left< S_{\alpha} \right> }{\partial U_{\gamma}}  =
      \beta \left( \left<S_{\alpha} \right>\left<S_{\gamma} \right> - \left<S_{\alpha} S_{\gamma} \right>  \right)~,
      \nonumber\end{aligned}
@@ -322,16 +323,15 @@ To get a well defined cross correlation matrix,
 enough smapling or the initial potential guess is far from the real
 solution of the inverse problem, the algorithm might not converge to a
 stable solution. To overcome this instability problem one could
-reformulate equation [eq:covariance] by addition of a penalty term. In
+reformulate :ref:`the above equation<theory_eq_covariance>` by addition of a penalty term. In
 this case the potential update is computed as
 follows:[Murtola:2007]_
 
 .. math::
 
-   \label{eq:regularization}
    \Delta U_\gamma = \arg \min \| A_{\alpha \gamma} \Delta U_\gamma - \left(\left<S_{\alpha}\right> - S_{\alpha}^{\text{ref}}\right) \|^2 + \lambda \| R \Delta U_{\gamma} \|^{2}
 
-Equation [eq:regularization] is known as Tikhonov regularization, where
+This equation is known as Tikhonov regularization, where
 :math:`R` is the regularization operator, which here is the identity
 matrix and :math:`\lambda >0 ` is the regularization parameter. The
 optimal choice for :math:`\lambda` can only be determined if the exact
@@ -429,24 +429,25 @@ the forces are not provided, it is assumed that :math:`d_{Ij} = c_{Ij}`
 By calculating the reference forces for :math:`L` snapshots we can write
 down :math:`N \times L` equations
 
+.. _theory_eq_fmatch1:
+
 .. math::
 
    {{{{\mathbf F}}}}_{Il}^\text{cg}(g_1, \dots ,g_M)={{{\mathbf F}}}_{il}^\text{ref},\;
      I=1,\dots,N,\; l=1,\dots,L~.
-     \label{eq:fmatch1}
 
 Here :math:`{{{{\mathbf F}}}}_{Il}^\text{ref}` is the force on
 the bead :math:`I` and :math:`{{{{\mathbf F}}}}_{Il}^\text{cg} `
 is the coarse-grained representation of this force. The index :math:`l`
 enumerates snapshots picked for coarse-graining. By running the
 simulations long enough one can always ensure that
-:math:`M < N \times L`. In this case the set of equations [eq:fmatch1]
+:math:`M < N times L`. In this case the set of equations
 is overdetermined and can be solved in a least-squares manner.
 
 :math:`{\mathbf F}_{il}^\text{cg}` is, in principle, a non-linear function
 of its parameters :math:`\{g_i\}`. Therefore, it is useful to represent
 the coarse-grained force-field in such a way that
-equations ([eq:fmatch1]) become linear functions of :math:`\{g_i\}`.
+:ref:`equations <theory_eq_fmatch1>` become linear functions of :math:`{g_i}`.
 This can be done using splines to describe the functional form of the
 forces [Izvekov:2005]_. Implementation details are
 discussed in ref. [Ruehle:2009.a]_.
@@ -473,9 +474,10 @@ the target AA ensemble.
 Relative entropy, :math:`S_{\text{rel}}`, is defined as
 [Shell2008]_
 
+.. _theory_eq_srel:
+
 .. math::
 
-   \label{eq:srel}
    S_{\text{rel}} = \sum_{i}p_{\text{AA}}(r_i) \ln\left(
      \frac{p_{\text{AA}}(r_i)}{p_{\text{CG}}\left(M(r_i)\right)}\right) +
    \langle S_{\text{map}} \rangle_{\text{AA}},
@@ -505,11 +507,13 @@ minimization of :math:`S_{\text{rel}}` with respect to the parameters of
 the CG model can be used to optimize the CG model.
 
 In a canonical ensemble, substituting canonical configurational
-probabilities into eq. [eq:srel], the relative entropy simplifies to
+probabilities into :ref:`the definition for the relative entropy<theory_eq_srel>`,
+it simplifies to
+
+.. _theory_eq_srelcan:
 
 .. math::
 
-   \label{eq:srelcan}
    S_{\text{rel}}=\beta\langle U_{\text{CG}} - U_{\text{AA}}\rangle_{\text{AA}}
    - \beta\left( A_{\text{CG}} - A_{\text{AA}}\right)
    + \langle S_{\text{map}}\rangle_{\text{AA}} ,
@@ -543,12 +547,11 @@ where :math:`k` is the iteration index, :math:`\chi\in(0...1)` is the
 scaling parameter that can be adjusted to ensure convergence,
 :math:`\nabla_{\lambda}S_{\text{rel}}` is the vector of the first
 derivatives of :math:`S_{\text{rel}}` with respect to
-:math:`\boldsymbol\lambda`, which can be computed from eq. [eq:srelcan]
+:math:`boldsymbollambda`, which can be computed from `the above equation<theory_eq_srelcan>`
 as
 
 .. math::
 
-   \label{eq:dsrel}
    \nabla_{\lambda}S_{\text{rel}} = \beta \left\langle \frac{\partial
      U_{\text{CG}}}{\partial\lambda}\right\rangle_{\text{AA}} - \beta\left\langle
    \frac{\partial U_{\text{CG}}}{\partial\lambda}\right\rangle_{\text{CG}} ,
@@ -559,7 +562,6 @@ given by
 .. math::
 
    \begin{aligned}
-   \label{eq:Hsrel}
    \mathbf{H}_{ij}&=&\beta \left\langle \frac{\partial^2
      U_{\text{CG}}}{\partial\lambda_i\partial\lambda_j}\right \rangle_{\text{AA}} -
    \beta \left\langle \frac{\partial^2
@@ -572,7 +574,7 @@ given by
    \frac{\partial U_{\text{CG}}}{\partial\lambda_j}\right\rangle_{\text{CG}}.\end{aligned}
 
 To compute :math:`\nabla_{\lambda}S_{\text{rel}}` and :math:`\mathbf{H}`
-from eq. [eq:dsrel] and [eq:Hsrel], we need average CG energy
+from those two equations, we need average CG energy
 derivatives in the AA and CG ensembles. For two-body CG pair potentials,
 :math:`u_{\text{CG}}`, between CG sites, the ensemble averages of the CG
 energy derivatives can be computed as

--- a/share/doc/theory.rst
+++ b/share/doc/theory.rst
@@ -189,7 +189,7 @@ so that the non-bonded interactions in the reference system do not
 contribute to the bonded interactions of the coarse-grained model.
 
 This can be done by employing exclusion lists using with the option
-``—excl``. This is described in detail in :ref: `_methods_exclusions`.
+``—excl``. This is described in detail in :ref:`methods_exclusions`.
 
 .. figure:: fig/excl.png
    :align: center
@@ -214,8 +214,8 @@ sampling step, followed by an update of the potential. The update itself
 often requires additional postprocessing such as smoothing,
 interpolation, extrapolation or fitting. Different methods are available
 to update the potential, for instance Iterative Boltzmann Inversion (see
-:ref: `_theory_iterative_boltzmann_inversion`) or Inverse Monte Carlo
-(see :ref: `_theory_inverse_monte_carlo`).
+:ref:`theory_iterative_boltzmann_inversion`) or Inverse Monte Carlo
+(see :ref:`theory_inverse_monte_carlo`).
 The whole procedure is then iterated until a convergence criterion is
 satisfied.
 
@@ -414,12 +414,12 @@ atoms
      \label{eq:force_mapping}
 
 where the sum is over all atoms of the CG site *I* (see
-:ref: `_theory_mapping`). The :math:`d_{Ij}` coefficients can, in
+:ref:`theory_mapping`). The :math:`d_{Ij}` coefficients can, in
 principle, be chosen arbitrarily, provided that the condition
 :math:` \sum_{i=1}^{n}d_{Ii}=1` is
 satisfied [Noid:2008.1]_. If mapping coefficients for
 the forces are not provided, it is assumed that :math:`d_{Ij} = c_{Ij}`
-(see also :ref: `_input_files`).
+(see also :ref:`input_files`).
 
 By calculating the reference forces for :math:`L` snapshots we can write
 down :math:`N \times L` equations


### PR DESCRIPTION
Sorry, I messed up the RST syntax for references. I did in a way, that Sphinx did not throw errors, but there were no links.
Should have checked the results better. This is the fix.

There were also several broken links to figures and equations, which I fixed.

Certainly the style of the text, specifically reference style in many places, still feels like it is compiled into a single latex document. Not sure how or if this should be changed. I think we should use numbers for equations, clicking a link to know which equation is meant is really awkward.