### PR TITLE
Lammps reader

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Version 2022-dev
 -  adapted tokenizer api (#693)
 -  made membervariable format consistent (#694)
 -  removed unused functions (#702)
+-  reworked lammps molecule naming (#703)
 
 Version 2021.2 (released XX.07.21)
 ==================================

--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -16,8 +16,13 @@
  */
 
 // Standard includes
+#include <cstddef>
+#include <iterator>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
+#include <set>
 
 // VOTCA includes
 #include <votca/tools/elements.h>
@@ -28,6 +33,7 @@
 #include <boost/algorithm/string.hpp>
 
 // Local VOTCA includes
+#include "votca/csg/molecule.h"
 #include "votca/csg/topology.h"
 
 // Local private VOTCA includes
@@ -89,9 +95,8 @@ bool LAMMPSDataReader::ReadTopology(string file, Topology &top) {
   NextFrame(top);
 
   fl_.close();
-  for (auto &mol : top.Molecules()) {
-    RenameMolecule(mol);
-  }
+
+  RenameMolecules(top.Molecules());
 
   return true;
 }
@@ -135,7 +140,7 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
       MatchFourFieldLabels_(fields, top);
     } else if (fields.size() != 0) {
       string err = "Unrecognized line in lammps .data file:\n" + line;
-      throw runtime_error(err);
+      throw std::runtime_error(err);
     }
     tools::getline(fl_, line);
   }
@@ -146,23 +151,55 @@ bool LAMMPSDataReader::NextFrame(Topology &top) {
  * Private Facing Methods                                                    *
  *****************************************************************************/
 
-void LAMMPSDataReader::RenameMolecule(Molecule &mol) const {
-  if (mol.getName() == "UNKNOWN") {
-    std::map<std::string, Index> molname_map;
-    for (const Bead *atom : mol.Beads()) {
-      std::string atomname = atom->getName();
-      std::string element = atomname.substr(0, 1);
-      if (std::islower(atomname[1])) {
-        element += atomname[1];
-      }
-      molname_map[element]++;
-    }
+std::pair<std::string, std::string> getNames(const Molecule &mol) {
 
-    std::string molname = "";
-    for (auto const &pair : molname_map) {
-      molname += (pair.first + std::to_string(pair.second));
+  std::string longname = "";
+  std::map<std::string, Index> molname_map;
+  for (const Bead *atom : mol.Beads()) {
+    std::string atomname = atom->getName();
+    std::string element = atomname.substr(0, 1);
+    if (std::islower(atomname[1])) {
+      element += atomname[1];
     }
-    mol.setName(molname);
+    longname += element;
+    molname_map[element]++;
+  }
+
+  // We compress the molecule into its chemical composition + an index
+  std::string shortname = "";
+  for (auto const &pair : molname_map) {
+    shortname += pair.first+std::to_string(pair.second);
+  }
+  return std::make_pair(shortname, longname);
+}
+
+void LAMMPSDataReader::RenameMolecules(MoleculeContainer &molecules) const {
+
+  std::map<std::string, std::set<std::string>> shortname_longnames;
+  // create compressed and long names for each molecule
+  for (const auto &mol : molecules) {
+    if (mol.getName() == "UNKNOWN") {
+      auto names = getNames(mol);
+      shortname_longnames[names.first].insert(names.second);
+    }
+  }
+
+  for (auto &mol : molecules) {
+    if (mol.getName() == "UNKNOWN") {
+      auto names = getNames(mol);
+      // if only one longname exists for a shortname, just use the shortname
+      if (shortname_longnames[names.first].size() == 1) {
+        mol.setName(names.first);
+      } else {
+        // if more than one longname exists for a shortname, sort the longnames
+        // alphabetically and just append the index to the short name
+        // e.g. if you have CCCH and CHCC they will compress to C3H-0 and C3H-1 respectively
+        ptrdiff_t i =
+            std::distance(shortname_longnames[names.first].begin(),
+                          shortname_longnames[names.first].find(names.second));
+        mol.setName(names.first + "-" + std::to_string(i));
+      }
+    }
   }
 }
 
@@ -535,6 +572,13 @@ void LAMMPSDataReader::ReadBonds_(Topology &top) {
 
       Index atom1Index = atomIdToIndex_[atom1Id];
       Index atom2Index = atomIdToIndex_[atom2Id];
+      if (atomIdToMoleculeId_[atom1Index] != atomIdToMoleculeId_[atom2Index]) {
+        throw std::runtime_error(
+            "Lammps Atoms " + std::to_string(atom1Id + 1) + " and " +
+            std::to_string(atom2Id + 1) + " belong to different molecules (" +
+            std::to_string(atomIdToMoleculeId_[atom1Index] + 1) + ":" +
+            std::to_string(atomIdToMoleculeId_[atom2Index] + 1) + ")");
+      }
 
       Interaction *ic = new IBond(atom1Index, atom2Index);
       ic->setGroup("BONDS");

--- a/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/src/libcsg/modules/io/lammpsdatareader.cc
@@ -18,11 +18,11 @@
 // Standard includes
 #include <cstddef>
 #include <iterator>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-#include <set>
 
 // VOTCA includes
 #include <votca/tools/elements.h>
@@ -168,7 +168,7 @@ std::pair<std::string, std::string> getNames(const Molecule &mol) {
   // We compress the molecule into its chemical composition + an index
   std::string shortname = "";
   for (auto const &pair : molname_map) {
-    shortname += pair.first+std::to_string(pair.second);
+    shortname += pair.first + std::to_string(pair.second);
   }
   return std::make_pair(shortname, longname);
 }
@@ -193,7 +193,8 @@ void LAMMPSDataReader::RenameMolecules(MoleculeContainer &molecules) const {
       } else {
         // if more than one longname exists for a shortname, sort the longnames
         // alphabetically and just append the index to the short name
-        // e.g. if you have CCCH and CHCC they will compress to C3H-0 and C3H-1 respectively
+        // e.g. if you have CCCH and CHCC they will compress to C3H-0 and C3H-1
+        // respectively
         ptrdiff_t i =
             std::distance(shortname_longnames[names.first].begin(),
                           shortname_longnames[names.first].find(names.second));

--- a/src/libcsg/modules/io/lammpsdatareader.h
+++ b/src/libcsg/modules/io/lammpsdatareader.h
@@ -120,7 +120,7 @@ class LAMMPSDataReader : public TrajectoryReader, public TopologyReader {
   void ReadDihedrals_(Topology &top);
   void SkipImpropers_();
 
-  void RenameMolecule(Molecule &mol) const;
+  void RenameMolecules(MoleculeContainer &molecules) const;
 
   enum lammps_format {
     style_angle_bond_molecule = 0,

--- a/src/tests/DataFiles/lammpsdatareader/test_bondedmolecules.data
+++ b/src/tests/DataFiles/lammpsdatareader/test_bondedmolecules.data
@@ -1,0 +1,55 @@
+LAMMPS data file. 
+ 6 atoms
+ 5 bonds
+ 2 angles
+ 0 dihedrals
+ 0 impropers
+ 2 atom types
+ 2 bond types
+ 1 angle types
+ 0 dihedral types
+ 0 improper types
+ -100 101.0  xlo xhi
+ -100 101.0  ylo yhi
+ -100 101.0  zlo zhi
+
+Masses
+
+1 16.000000
+2 1.000000
+
+Pair Coeffs
+
+1 0.210000 2.959920
+2 0.170000 3.000010
+
+Bond Coeffs
+
+1 344.300000 1.087000
+2 418.300000 1.429000
+
+Angle Coeffs
+
+1 48.460000 120.010000
+
+Atoms
+
+1 1 1 -0.1062000 -22.5210000 18.0870000 1.5060000
+2 1 2 0.0472000 -21.6720010 17.5630000 1.1950000
+3 1 2 0.0472000 -23.2719990 17.3309990 1.7360000
+4 2 2 -0.0084000 -22.9100000 19.2029990 0.5070000
+5 2 2 0.0688000 -21.9800000 19.7400000 0.1950000
+6 2 1 0.0269000 -23.7840000 20.2339990 1.1660000
+
+Bonds
+
+1 1 1 2
+2 1 1 3
+3 1 4 6
+4 1 5 6
+5 1 1 6
+# The last bond is failing because it connects two molecules
+Angles
+
+1 1 2 1 3
+2 1 4 6 5

--- a/src/tests/DataFiles/lammpsdatareader/test_twomolecules.data
+++ b/src/tests/DataFiles/lammpsdatareader/test_twomolecules.data
@@ -1,0 +1,53 @@
+LAMMPS data file. 
+ 6 atoms
+ 4 bonds
+ 2 angles
+ 0 dihedrals
+ 0 impropers
+ 2 atom types
+ 1 bond types
+ 1 angle types
+ 0 dihedral types
+ 0 improper types
+ -100 101.0  xlo xhi
+ -100 101.0  ylo yhi
+ -100 101.0  zlo zhi
+
+Masses
+
+1 16.000000
+2 1.000000
+
+Pair Coeffs
+
+1 0.210000 2.959920
+2 0.170000 3.000010
+
+Bond Coeffs
+
+1 344.300000 1.087000
+
+Angle Coeffs
+
+1 48.460000 120.010000
+
+Atoms
+#changing order of atoms in molecule should lead two different names H2O1-0 and H2O1-1
+1 1 1 -0.1062000 -22.5210000 18.0870000 1.5060000
+2 1 2 0.0472000 -21.6720010 17.5630000 1.1950000
+3 1 2 0.0472000 -23.2719990 17.3309990 1.7360000
+4 2 2 -0.0084000 -22.9100000 19.2029990 0.5070000
+5 2 2 0.0688000 -21.9800000 19.7400000 0.1950000
+6 2 1 0.0269000 -23.7840000 20.2339990 1.1660000
+
+Bonds
+
+1 1 1 2
+2 1 1 3
+3 1 4 6
+4 1 5 6
+
+Angles
+
+1 1 2 1 3
+2 1 4 6 5

--- a/src/tests/test_lammpsdatareader.cc
+++ b/src/tests/test_lammpsdatareader.cc
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2009-2021 The VOTCA Development Team (http://www.votca.org)
  *
@@ -63,8 +64,7 @@ BOOST_AUTO_TEST_CASE(test_topologyreader) {
 
   TopologyReader::RegisterPlugins();
   std::unique_ptr<TopologyReader> lammpsDataReader =
-      std::unique_ptr<TopologyReader>(
-          TopReaderFactory().Create(lammpsdatafilename));
+      TopReaderFactory().Create(lammpsdatafilename);
   lammpsDataReader->ReadTopology(lammpsdatafilename, top);
 
   BOOST_CHECK_EQUAL(top.BeadCount(), 100);
@@ -109,8 +109,7 @@ BOOST_AUTO_TEST_CASE(test_trajectoryreader) {
 
   TopologyReader::RegisterPlugins();
   std::unique_ptr<TopologyReader> lammpsDataReader =
-      std::unique_ptr<TopologyReader>(
-          TopReaderFactory().Create(lammpsdatafilename));
+      TopReaderFactory().Create(lammpsdatafilename);
   lammpsDataReader->ReadTopology(lammpsdatafilename, top);
 
   string lammpsdatafilename2 = std::string(CSG_TEST_DATA_FOLDER) +
@@ -118,8 +117,7 @@ BOOST_AUTO_TEST_CASE(test_trajectoryreader) {
 
   TrajectoryReader::RegisterPlugins();
   std::unique_ptr<TrajectoryReader> lammpsDataReaderTrj =
-      std::unique_ptr<TrajectoryReader>(
-          TrjReaderFactory().Create(lammpsdatafilename2));
+      TrjReaderFactory().Create(lammpsdatafilename2);
 
   lammpsDataReaderTrj->Open(lammpsdatafilename2);
   lammpsDataReaderTrj->FirstFrame(top);
@@ -152,6 +150,34 @@ BOOST_AUTO_TEST_CASE(test_trajectoryreader) {
   votca::Index numDihedralInter = 97;
   votca::Index totalInter = numBondInter + numAngleInter + numDihedralInter;
   BOOST_CHECK_EQUAL(interaction_cont.size(), totalInter);
+}
+
+BOOST_AUTO_TEST_CASE(test_molecules) {
+
+  string lammpsdatafilename = std::string(CSG_TEST_DATA_FOLDER) +
+                              "/lammpsdatareader/test_bondedmolecules.data";
+  Topology top;
+
+  TopologyReader::RegisterPlugins();
+  std::unique_ptr<TopologyReader> lammpsDataReader =
+      TopReaderFactory().Create(lammpsdatafilename);
+  BOOST_REQUIRE_THROW(lammpsDataReader->ReadTopology(lammpsdatafilename, top),
+                    std::runtime_error);
+  string lammpsdatafilename2 = std::string(CSG_TEST_DATA_FOLDER) +
+                               "/lammpsdatareader/test_twomolecules.data";
+
+  Topology top2;
+  std::unique_ptr<TopologyReader> lammpsDataReader2 =
+      TopReaderFactory().Create(lammpsdatafilename2);
+
+  lammpsDataReader2->ReadTopology(lammpsdatafilename2, top2);
+  std::vector<std::string> refnames{"H2O1-1", "H2O1-0"};
+  // the first molecule has order OHH while the second has HHO so the second is lexicographically first
+  votca::Index i = 0;
+  for (const auto &mol : top2.Molecules()) {
+    BOOST_CHECK_EQUAL(mol.getName(), refnames[i]);
+    i++;
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_lammpsdatareader.cc
+++ b/src/tests/test_lammpsdatareader.cc
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_molecules) {
   std::unique_ptr<TopologyReader> lammpsDataReader =
       TopReaderFactory().Create(lammpsdatafilename);
   BOOST_REQUIRE_THROW(lammpsDataReader->ReadTopology(lammpsdatafilename, top),
-                    std::runtime_error);
+                      std::runtime_error);
   string lammpsdatafilename2 = std::string(CSG_TEST_DATA_FOLDER) +
                                "/lammpsdatareader/test_twomolecules.data";
 
@@ -172,7 +172,8 @@ BOOST_AUTO_TEST_CASE(test_molecules) {
 
   lammpsDataReader2->ReadTopology(lammpsdatafilename2, top2);
   std::vector<std::string> refnames{"H2O1-1", "H2O1-0"};
-  // the first molecule has order OHH while the second has HHO so the second is lexicographically first
+  // the first molecule has order OHH while the second has HHO so the second is
+  // lexicographically first
   votca::Index i = 0;
   for (const auto &mol : top2.Molecules()) {
     BOOST_CHECK_EQUAL(mol.getName(), refnames[i]);


### PR DESCRIPTION
This PR does two things:

a) throw an error when votca tries to construct a bond between atoms from different molecules in the lammps reader.

b) at the moment unnamed molecules are named by their chemical composition, this can be problematic if we have isomers in the topology in that case an index is added at the end of the molecule. 